### PR TITLE
Renamed the hand "Two Pairs" to "Two Pair".

### DIFF
--- a/src/engine/local_engine/cardsvalue.cpp
+++ b/src/engine/local_engine/cardsvalue.cpp
@@ -954,7 +954,7 @@ std::string CardsValue::determineHandName(int myCardsValueInt, PlayerList active
 		}
 	}
 	break;
-	// Two Pairs
+	// Two Pair
 	case 2: {
 
 		handName = *cardStringIt_c;
@@ -1775,9 +1775,9 @@ std::list<std::string> CardsValue::translateCardsValueCode(int cardsValueCode)
 		}
 	}
 	break;
-	// Two Pairs
+	// Two Pair
 	case 2: {
-		cardString.push_back("Two Pairs, ");
+		cardString.push_back("Two Pair, ");
 		// erster Pair
 		switch(secondPart) {
 		case 12:

--- a/src/gui/qt/gametable/mychancelabel.cpp
+++ b/src/gui/qt/gametable/mychancelabel.cpp
@@ -180,7 +180,7 @@ void MyChanceLabel::paintEvent(QPaintEvent * /*event*/)
 	} else {
 		painter.setPen(possible);
 	}
-	painter.drawText(QRectF(QPointF(2,start_y+7*height), QPointF(text_width,start_y+8*height)),Qt::AlignRight,"Two Pairs");
+	painter.drawText(QRectF(QPointF(2,start_y+7*height), QPointF(text_width,start_y+8*height)),Qt::AlignRight,"Two Pair");
 	painter.drawText(QRectF(QPointF(percent_start,start_y+7*height), QPointF(percent_start+percent_width,start_y+8*height)),Qt::AlignRight,QString("%1%").arg(TPChance[0]));
 	if(OPChance[1] == 0 || myFoldState) {
 		painter.setPen(impossible);


### PR DESCRIPTION
Nitpick, but the name of the hand is "Two Pair".
https://en.wikipedia.org/wiki/Two_pair#Two_pair

English is a funny language.

This commit does not correct the name of the hand in any images (for
example data/gfx/gui/table/default/handranking.png) because the
corresponding GIMP templates do not have separate text layers, making
them difficult to edit.
