### PR TITLE
Fix compilation on FreeBSD and Hurd

### DIFF
--- a/pokerth.proto
+++ b/pokerth.proto
@@ -129,8 +129,8 @@ message PlayerResult {
 
 message AnnounceMessage {
 	message Version {
-		required	uint32		major = 1;
-		required	uint32		minor = 2;
+		required	uint32		majorVersion = 1;
+		required	uint32		minorVersion = 2;
 	}
 	required	Version			protocolVersion = 1;
 	required	Version			latestGameVersion = 2;

--- a/src/net/common/clientstate.cpp
+++ b/src/net/common/clientstate.cpp
@@ -848,8 +848,8 @@ ClientStateStartSession::InternalHandlePacket(boost::shared_ptr<ClientThread> cl
 		// Server has send announcement - check data.
 		const AnnounceMessage &netAnnounce = tmpPacket->GetMsg()->announcemessage();
 		// Check current game version.
-		if (netAnnounce.latestgameversion().major() != POKERTH_VERSION_MAJOR
-				|| netAnnounce.latestgameversion().minor() != POKERTH_VERSION_MINOR) {
+		if (netAnnounce.latestgameversion().majorversion() != POKERTH_VERSION_MAJOR
+				|| netAnnounce.latestgameversion().minorversion() != POKERTH_VERSION_MINOR) {
 			client->GetCallback().SignalNetClientNotification(NTF_NET_NEW_RELEASE_AVAILABLE);
 		} else if (POKERTH_BETA_REVISION && netAnnounce.latestbetarevision() != POKERTH_BETA_REVISION) {
 			client->GetCallback().SignalNetClientNotification(NTF_NET_OUTDATED_BETA);
@@ -867,8 +867,8 @@ ClientStateStartSession::InternalHandlePacket(boost::shared_ptr<ClientThread> cl
 			boost::shared_ptr<NetPacket> init(new NetPacket);
 			init->GetMsg()->set_messagetype(PokerTHMessage::Type_InitMessage);
 			InitMessage *netInit = init->GetMsg()->mutable_initmessage();
-			netInit->mutable_requestedversion()->set_major(NET_VERSION_MAJOR);
-			netInit->mutable_requestedversion()->set_minor(NET_VERSION_MINOR);
+			netInit->mutable_requestedversion()->set_majorversion(NET_VERSION_MAJOR);
+			netInit->mutable_requestedversion()->set_minorversion(NET_VERSION_MINOR);
 			netInit->set_buildid(0);
 			if (!context.GetSessionGuid().empty()) {
 				netInit->set_mylastsessionid(context.GetSessionGuid());
@@ -946,8 +946,8 @@ ClientStateWaitEnterLogin::TimerLoop(const boost::system::error_code& ec, boost:
 			boost::shared_ptr<NetPacket> init(new NetPacket);
 			init->GetMsg()->set_messagetype(PokerTHMessage::Type_InitMessage);
 			InitMessage *netInit = init->GetMsg()->mutable_initmessage();
-			netInit->mutable_requestedversion()->set_major(NET_VERSION_MAJOR);
-			netInit->mutable_requestedversion()->set_minor(NET_VERSION_MINOR);
+			netInit->mutable_requestedversion()->set_majorversion(NET_VERSION_MAJOR);
+			netInit->mutable_requestedversion()->set_minorversion(NET_VERSION_MINOR);
 			netInit->set_buildid(0);
 			if (!context.GetSessionGuid().empty()) {
 				netInit->set_mylastsessionid(context.GetSessionGuid());

--- a/src/net/common/serverlobbythread.cpp
+++ b/src/net/common/serverlobbythread.cpp
@@ -282,10 +282,10 @@ ServerLobbyThread::AddConnection(boost::shared_ptr<tcp::socket> sock)
 				boost::shared_ptr<NetPacket> packet(new NetPacket);
 				packet->GetMsg()->set_messagetype(PokerTHMessage::Type_AnnounceMessage);
 				AnnounceMessage *netAnnounce = packet->GetMsg()->mutable_announcemessage();
-				netAnnounce->mutable_protocolversion()->set_major(NET_VERSION_MAJOR);
-				netAnnounce->mutable_protocolversion()->set_minor(NET_VERSION_MINOR);
-				netAnnounce->mutable_latestgameversion()->set_major(POKERTH_VERSION_MAJOR);
-				netAnnounce->mutable_latestgameversion()->set_minor(POKERTH_VERSION_MINOR);
+				netAnnounce->mutable_protocolversion()->set_majorversion(NET_VERSION_MAJOR);
+				netAnnounce->mutable_protocolversion()->set_minorversion(NET_VERSION_MINOR);
+				netAnnounce->mutable_latestgameversion()->set_majorversion(POKERTH_VERSION_MAJOR);
+				netAnnounce->mutable_latestgameversion()->set_minorversion(POKERTH_VERSION_MINOR);
 				netAnnounce->set_latestbetarevision(POKERTH_BETA_REVISION);
 				switch (GetServerMode()) {
 				case SERVER_MODE_LAN:
@@ -957,7 +957,7 @@ ServerLobbyThread::HandleNetPacketInit(boost::shared_ptr<SessionData> session, c
 	}
 
 	// Check the protocol version.
-	if (initMessage.requestedversion().major() != NET_VERSION_MAJOR
+	if (initMessage.requestedversion().majorversion() != NET_VERSION_MAJOR
 			|| session->GetPlayerData()) { // Has this session already sent an init?
 		SessionError(session, ERR_NET_VERSION_NOT_SUPPORTED);
 		return;

--- a/src/third_party/protobuf/pokerth.pb.cc
+++ b/src/third_party/protobuf/pokerth.pb.cc
@@ -1465,8 +1465,8 @@ const AnnounceMessage_ServerType AnnounceMessage::ServerType_MAX;
 const int AnnounceMessage::ServerType_ARRAYSIZE;
 #endif  // _MSC_VER
 #ifndef _MSC_VER
-const int AnnounceMessage_Version::kMajorFieldNumber;
-const int AnnounceMessage_Version::kMinorFieldNumber;
+const int AnnounceMessage_Version::kMajorVersionFieldNumber;
+const int AnnounceMessage_Version::kMinorVersionFieldNumber;
 #endif  // !_MSC_VER
 
 AnnounceMessage_Version::AnnounceMessage_Version()
@@ -1485,8 +1485,8 @@ AnnounceMessage_Version::AnnounceMessage_Version(const AnnounceMessage_Version& 
 
 void AnnounceMessage_Version::SharedCtor() {
   _cached_size_ = 0;
-  major_ = 0u;
-  minor_ = 0u;
+  majorversion_ = 0u;
+  minorversion_ = 0u;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -1516,8 +1516,8 @@ AnnounceMessage_Version* AnnounceMessage_Version::New() const {
 
 void AnnounceMessage_Version::Clear() {
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    major_ = 0u;
-    minor_ = 0u;
+    majorversion_ = 0u;
+    minorversion_ = 0u;
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
@@ -1528,30 +1528,30 @@ bool AnnounceMessage_Version::MergePartialFromCodedStream(
   ::google::protobuf::uint32 tag;
   while ((tag = input->ReadTag()) != 0) {
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // required uint32 major = 1;
+      // required uint32 majorVersion = 1;
       case 1: {
         if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
             ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
-                 input, &major_)));
-          set_has_major();
+                 input, &majorversion_)));
+          set_has_majorversion();
         } else {
           goto handle_uninterpreted;
         }
-        if (input->ExpectTag(16)) goto parse_minor;
+        if (input->ExpectTag(16)) goto parse_minorVersion;
         break;
       }
       
-      // required uint32 minor = 2;
+      // required uint32 minorVersion = 2;
       case 2: {
         if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
             ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
-         parse_minor:
+         parse_minorVersion:
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
-                 input, &minor_)));
-          set_has_minor();
+                 input, &minorversion_)));
+          set_has_minorversion();
         } else {
           goto handle_uninterpreted;
         }
@@ -1576,14 +1576,14 @@ bool AnnounceMessage_Version::MergePartialFromCodedStream(
 
 void AnnounceMessage_Version::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // required uint32 major = 1;
-  if (has_major()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt32(1, this->major(), output);
+  // required uint32 majorVersion = 1;
+  if (has_majorversion()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(1, this->majorversion(), output);
   }
   
-  // required uint32 minor = 2;
-  if (has_minor()) {
-    ::google::protobuf::internal::WireFormatLite::WriteUInt32(2, this->minor(), output);
+  // required uint32 minorVersion = 2;
+  if (has_minorversion()) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32(2, this->minorversion(), output);
   }
   
 }
@@ -1592,18 +1592,18 @@ int AnnounceMessage_Version::ByteSize() const {
   int total_size = 0;
   
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // required uint32 major = 1;
-    if (has_major()) {
+    // required uint32 majorVersion = 1;
+    if (has_majorversion()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::UInt32Size(
-          this->major());
+          this->majorversion());
     }
     
-    // required uint32 minor = 2;
-    if (has_minor()) {
+    // required uint32 minorVersion = 2;
+    if (has_minorversion()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::UInt32Size(
-          this->minor());
+          this->minorversion());
     }
     
   }
@@ -1621,11 +1621,11 @@ void AnnounceMessage_Version::CheckTypeAndMergeFrom(
 void AnnounceMessage_Version::MergeFrom(const AnnounceMessage_Version& from) {
   GOOGLE_CHECK_NE(&from, this);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_major()) {
-      set_major(from.major());
+    if (from.has_majorversion()) {
+      set_majorversion(from.majorversion());
     }
-    if (from.has_minor()) {
-      set_minor(from.minor());
+    if (from.has_minorversion()) {
+      set_minorversion(from.minorversion());
     }
   }
 }
@@ -1644,8 +1644,8 @@ bool AnnounceMessage_Version::IsInitialized() const {
 
 void AnnounceMessage_Version::Swap(AnnounceMessage_Version* other) {
   if (other != this) {
-    std::swap(major_, other->major_);
-    std::swap(minor_, other->minor_);
+    std::swap(majorversion_, other->majorversion_);
+    std::swap(minorversion_, other->minorversion_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     std::swap(_cached_size_, other->_cached_size_);
   }

--- a/src/third_party/protobuf/pokerth.pb.h
+++ b/src/third_party/protobuf/pokerth.pb.h
@@ -929,29 +929,29 @@ class AnnounceMessage_Version : public ::google::protobuf::MessageLite {
   
   // accessors -------------------------------------------------------
   
-  // required uint32 major = 1;
-  inline bool has_major() const;
-  inline void clear_major();
-  static const int kMajorFieldNumber = 1;
-  inline ::google::protobuf::uint32 major() const;
-  inline void set_major(::google::protobuf::uint32 value);
+  // required uint32 majorVersion = 1;
+  inline bool has_majorversion() const;
+  inline void clear_majorversion();
+  static const int kMajorVersionFieldNumber = 1;
+  inline ::google::protobuf::uint32 majorversion() const;
+  inline void set_majorversion(::google::protobuf::uint32 value);
   
-  // required uint32 minor = 2;
-  inline bool has_minor() const;
-  inline void clear_minor();
-  static const int kMinorFieldNumber = 2;
-  inline ::google::protobuf::uint32 minor() const;
-  inline void set_minor(::google::protobuf::uint32 value);
+  // required uint32 minorVersion = 2;
+  inline bool has_minorversion() const;
+  inline void clear_minorversion();
+  static const int kMinorVersionFieldNumber = 2;
+  inline ::google::protobuf::uint32 minorversion() const;
+  inline void set_minorversion(::google::protobuf::uint32 value);
   
   // @@protoc_insertion_point(class_scope:AnnounceMessage.Version)
  private:
-  inline void set_has_major();
-  inline void clear_has_major();
-  inline void set_has_minor();
-  inline void clear_has_minor();
+  inline void set_has_majorversion();
+  inline void clear_has_majorversion();
+  inline void set_has_minorversion();
+  inline void clear_has_minorversion();
   
-  ::google::protobuf::uint32 major_;
-  ::google::protobuf::uint32 minor_;
+  ::google::protobuf::uint32 majorversion_;
+  ::google::protobuf::uint32 minorversion_;
   
   mutable int _cached_size_;
   ::google::protobuf::uint32 _has_bits_[(2 + 31) / 32];
@@ -9601,48 +9601,48 @@ inline void PlayerResult::set_cardsvalue(::google::protobuf::uint32 value) {
 
 // AnnounceMessage_Version
 
-// required uint32 major = 1;
-inline bool AnnounceMessage_Version::has_major() const {
+// required uint32 majorVersion = 1;
+inline bool AnnounceMessage_Version::has_majorversion() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void AnnounceMessage_Version::set_has_major() {
+inline void AnnounceMessage_Version::set_has_majorversion() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void AnnounceMessage_Version::clear_has_major() {
+inline void AnnounceMessage_Version::clear_has_majorversion() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void AnnounceMessage_Version::clear_major() {
-  major_ = 0u;
-  clear_has_major();
+inline void AnnounceMessage_Version::clear_majorversion() {
+  majorversion_ = 0u;
+  clear_has_majorversion();
 }
-inline ::google::protobuf::uint32 AnnounceMessage_Version::major() const {
-  return major_;
+inline ::google::protobuf::uint32 AnnounceMessage_Version::majorversion() const {
+  return majorversion_;
 }
-inline void AnnounceMessage_Version::set_major(::google::protobuf::uint32 value) {
-  set_has_major();
-  major_ = value;
+inline void AnnounceMessage_Version::set_majorversion(::google::protobuf::uint32 value) {
+  set_has_majorversion();
+  majorversion_ = value;
 }
 
-// required uint32 minor = 2;
-inline bool AnnounceMessage_Version::has_minor() const {
+// required uint32 minorVersion = 2;
+inline bool AnnounceMessage_Version::has_minorversion() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void AnnounceMessage_Version::set_has_minor() {
+inline void AnnounceMessage_Version::set_has_minorversion() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void AnnounceMessage_Version::clear_has_minor() {
+inline void AnnounceMessage_Version::clear_has_minorversion() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void AnnounceMessage_Version::clear_minor() {
-  minor_ = 0u;
-  clear_has_minor();
+inline void AnnounceMessage_Version::clear_minorversion() {
+  minorversion_ = 0u;
+  clear_has_minorversion();
 }
-inline ::google::protobuf::uint32 AnnounceMessage_Version::minor() const {
-  return minor_;
+inline ::google::protobuf::uint32 AnnounceMessage_Version::minorversion() const {
+  return minorversion_;
 }
-inline void AnnounceMessage_Version::set_minor(::google::protobuf::uint32 value) {
-  set_has_minor();
-  minor_ = value;
+inline void AnnounceMessage_Version::set_minorversion(::google::protobuf::uint32 value) {
+  set_has_minorversion();
+  minorversion_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/tests/src/de/pokerth/protocol/ProtoBuf.java
+++ b/tests/src/de/pokerth/protocol/ProtoBuf.java
@@ -2462,13 +2462,13 @@ public final class ProtoBuf {
     public interface VersionOrBuilder
         extends com.google.protobuf.MessageLiteOrBuilder {
       
-      // required uint32 major = 1;
-      boolean hasMajor();
-      int getMajor();
+      // required uint32 majorVersion = 1;
+      boolean hasMajorVersion();
+      int getMajorVersion();
       
-      // required uint32 minor = 2;
-      boolean hasMinor();
-      int getMinor();
+      // required uint32 minorVersion = 2;
+      boolean hasMinorVersion();
+      int getMinorVersion();
     }
     public static final class Version extends
         com.google.protobuf.GeneratedMessageLite
@@ -2489,40 +2489,40 @@ public final class ProtoBuf {
       }
       
       private int bitField0_;
-      // required uint32 major = 1;
-      public static final int MAJOR_FIELD_NUMBER = 1;
-      private int major_;
-      public boolean hasMajor() {
+      // required uint32 majorVersion = 1;
+      public static final int MAJORVERSION_FIELD_NUMBER = 1;
+      private int majorVersion_;
+      public boolean hasMajorVersion() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
-      public int getMajor() {
-        return major_;
+      public int getMajorVersion() {
+        return majorVersion_;
       }
       
-      // required uint32 minor = 2;
-      public static final int MINOR_FIELD_NUMBER = 2;
-      private int minor_;
-      public boolean hasMinor() {
+      // required uint32 minorVersion = 2;
+      public static final int MINORVERSION_FIELD_NUMBER = 2;
+      private int minorVersion_;
+      public boolean hasMinorVersion() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
-      public int getMinor() {
-        return minor_;
+      public int getMinorVersion() {
+        return minorVersion_;
       }
       
       private void initFields() {
-        major_ = 0;
-        minor_ = 0;
+        majorVersion_ = 0;
+        minorVersion_ = 0;
       }
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
         byte isInitialized = memoizedIsInitialized;
         if (isInitialized != -1) return isInitialized == 1;
         
-        if (!hasMajor()) {
+        if (!hasMajorVersion()) {
           memoizedIsInitialized = 0;
           return false;
         }
-        if (!hasMinor()) {
+        if (!hasMinorVersion()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -2534,10 +2534,10 @@ public final class ProtoBuf {
                           throws java.io.IOException {
         getSerializedSize();
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
-          output.writeUInt32(1, major_);
+          output.writeUInt32(1, majorVersion_);
         }
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
-          output.writeUInt32(2, minor_);
+          output.writeUInt32(2, minorVersion_);
         }
       }
       
@@ -2549,11 +2549,11 @@ public final class ProtoBuf {
         size = 0;
         if (((bitField0_ & 0x00000001) == 0x00000001)) {
           size += com.google.protobuf.CodedOutputStream
-            .computeUInt32Size(1, major_);
+            .computeUInt32Size(1, majorVersion_);
         }
         if (((bitField0_ & 0x00000002) == 0x00000002)) {
           size += com.google.protobuf.CodedOutputStream
-            .computeUInt32Size(2, minor_);
+            .computeUInt32Size(2, minorVersion_);
         }
         memoizedSerializedSize = size;
         return size;
@@ -2657,9 +2657,9 @@ public final class ProtoBuf {
         
         public Builder clear() {
           super.clear();
-          major_ = 0;
+          majorVersion_ = 0;
           bitField0_ = (bitField0_ & ~0x00000001);
-          minor_ = 0;
+          minorVersion_ = 0;
           bitField0_ = (bitField0_ & ~0x00000002);
           return this;
         }
@@ -2697,32 +2697,32 @@ public final class ProtoBuf {
           if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
             to_bitField0_ |= 0x00000001;
           }
-          result.major_ = major_;
+          result.majorVersion_ = majorVersion_;
           if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
             to_bitField0_ |= 0x00000002;
           }
-          result.minor_ = minor_;
+          result.minorVersion_ = minorVersion_;
           result.bitField0_ = to_bitField0_;
           return result;
         }
         
         public Builder mergeFrom(de.pokerth.protocol.ProtoBuf.AnnounceMessage.Version other) {
           if (other == de.pokerth.protocol.ProtoBuf.AnnounceMessage.Version.getDefaultInstance()) return this;
-          if (other.hasMajor()) {
-            setMajor(other.getMajor());
+          if (other.hasMajorVersion()) {
+            setMajorVersion(other.getMajorVersion());
           }
-          if (other.hasMinor()) {
-            setMinor(other.getMinor());
+          if (other.hasMinorVersion()) {
+            setMinorVersion(other.getMinorVersion());
           }
           return this;
         }
         
         public final boolean isInitialized() {
-          if (!hasMajor()) {
+          if (!hasMajorVersion()) {
             
             return false;
           }
-          if (!hasMinor()) {
+          if (!hasMinorVersion()) {
             
             return false;
           }
@@ -2748,12 +2748,12 @@ public final class ProtoBuf {
               }
               case 8: {
                 bitField0_ |= 0x00000001;
-                major_ = input.readUInt32();
+                majorVersion_ = input.readUInt32();
                 break;
               }
               case 16: {
                 bitField0_ |= 0x00000002;
-                minor_ = input.readUInt32();
+                minorVersion_ = input.readUInt32();
                 break;
               }
             }
@@ -2762,44 +2762,44 @@ public final class ProtoBuf {
         
         private int bitField0_;
         
-        // required uint32 major = 1;
-        private int major_ ;
-        public boolean hasMajor() {
+        // required uint32 majorVersion = 1;
+        private int majorVersion_ ;
+        public boolean hasMajorVersion() {
           return ((bitField0_ & 0x00000001) == 0x00000001);
         }
-        public int getMajor() {
-          return major_;
+        public int getMajorVersion() {
+          return majorVersion_;
         }
-        public Builder setMajor(int value) {
+        public Builder setMajorVersion(int value) {
           bitField0_ |= 0x00000001;
-          major_ = value;
+          majorVersion_ = value;
           
           return this;
         }
-        public Builder clearMajor() {
+        public Builder clearMajorVersion() {
           bitField0_ = (bitField0_ & ~0x00000001);
-          major_ = 0;
+          majorVersion_ = 0;
           
           return this;
         }
         
-        // required uint32 minor = 2;
-        private int minor_ ;
-        public boolean hasMinor() {
+        // required uint32 minorVersion = 2;
+        private int minorVersion_ ;
+        public boolean hasMinorVersion() {
           return ((bitField0_ & 0x00000002) == 0x00000002);
         }
-        public int getMinor() {
-          return minor_;
+        public int getMinorVersion() {
+          return minorVersion_;
         }
-        public Builder setMinor(int value) {
+        public Builder setMinorVersion(int value) {
           bitField0_ |= 0x00000002;
-          minor_ = value;
+          minorVersion_ = value;
           
           return this;
         }
-        public Builder clearMinor() {
+        public Builder clearMinorVersion() {
           bitField0_ = (bitField0_ & ~0x00000002);
-          minor_ = 0;
+          minorVersion_ = 0;
           
           return this;
         }


### PR DESCRIPTION
PokerTH fails to build on Debian GNU/kFreeBSD and GNU/Hurd with:

```
 In file included from src/third_party/protobuf/pokerth.pb.cc:4:0:
 src/third_party/protobuf/pokerth.pb.h:936:37: error: expected unqualified-id before 'int'
 src/third_party/protobuf/pokerth.pb.h:936:37: error: expected ')' before 'int'
 src/third_party/protobuf/pokerth.pb.h:936:37: error: expected ')' before 'int'
 src/third_party/protobuf/pokerth.pb.h:943:37: error: expected unqualified-id before 'int'
 src/third_party/protobuf/pokerth.pb.h:943:37: error: expected ')' before 'int'
 src/third_party/protobuf/pokerth.pb.h:943:37: error: expected ')' before 'int'
 src/third_party/protobuf/pokerth.pb.h:9618:60: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.h:9640:60: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.cc: In member function 'virtual void AnnounceMessage_Version::SerializeWithCachedSizes(google::protobuf::io::CodedOutputStream*) const':
 src/third_party/protobuf/pokerth.pb.cc:1581:72: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.cc:1581:72: error: expected primary-expression before ')' token
 src/third_party/protobuf/pokerth.pb.cc:1586:72: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.cc:1586:72: error: expected primary-expression before ')' token
 src/third_party/protobuf/pokerth.pb.cc: In member function 'virtual int AnnounceMessage_Version::ByteSize() const':
 src/third_party/protobuf/pokerth.pb.cc:1599:17: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.cc:1599:17: error: expected primary-expression before ')' token
 src/third_party/protobuf/pokerth.pb.cc:1606:17: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.cc:1606:17: error: expected primary-expression before ')' token
 src/third_party/protobuf/pokerth.pb.cc: In member function 'void AnnounceMessage_Version::MergeFrom(const AnnounceMessage_Version&)':
 src/third_party/protobuf/pokerth.pb.cc:1625:22: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.cc:1625:22: error: expected primary-expression before ')' token
 src/third_party/protobuf/pokerth.pb.cc:1628:22: error: expected unqualified-id before '(' token
 src/third_party/protobuf/pokerth.pb.cc:1628:22: error: expected primary-expression before ')' token
 src/third_party/protobuf/pokerth.pb.cc: At global scope:
 src/third_party/protobuf/pokerth.pb.cc:14319:6: warning: unused parameter 'output' [-Wunused-parameter]
 src/third_party/protobuf/pokerth.pb.cc:18344:6: warning: unused parameter 'output' [-Wunused-parameter]
 make[2]: *** [obj/pokerth.pb.o] Error 1
```

Renaming the vars to majorVersion/minorVersion fixes this issue.

The problem on kFreeBSD is, that
 `/usr/include/sys/kern/types.h`
has

```
 #define major(x)        ((int)(((u_int)(x) >> 8)&0xff)) /* major number */
 #define minor(x)        ((int)((x)&0xffff00ff))         /* minor number */
```

and this is included somewhere when you include stdlib.h, which protobuf's
headers do.

Hurd has similar definitions in `/usr/include/i386-gnu/sys/sysmacros.h`.
