### PR TITLE
Fix compilation on newer libircclient

### DIFF
--- a/src/net/common/ircthread.cpp
+++ b/src/net/common/ircthread.cpp
@@ -33,6 +33,7 @@
 #include <net/ircthread.h>
 #include <net/socket_msg.h>
 #include <libircclient/libircclient.h>
+#include <libircclient/libirc_rfcnumeric.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <queue>
 #include <sstream>


### PR DESCRIPTION
I got a lot of undefined symbols without this include. It appears to be required on recent libircclient versions.
