### PR TITLE
Fix compilation on newer libircclient

### DIFF
--- a/src/net/common/ircthread.cpp
+++ b/src/net/common/ircthread.cpp
@@ -33,7 +33,15 @@
 #include <net/ircthread.h>
 #include <net/socket_msg.h>
 #include <libircclient/libircclient.h>
+
+// We need to do the following to handle different versions of libircclient.
+// Sadly, libircclient doesn't have actual definitions for its versions in its headers.
+// However, we can use a definition that appeared in the same version we need
+// to check for. Hacky, but hey, it works.
+#ifdef LIBIRC_OPTION_SSL_NO_VERIFY
 #include <libircclient/libirc_rfcnumeric.h>
+#endif
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <queue>
 #include <sstream>


### PR DESCRIPTION
As opposed to my other pull request, this one only works on the newer versions where it's actually required.
