### PR TITLE
look for libs in $${PREFIX}/lib/$$system(gcc -print-multiarch)

### DIFF
--- a/connectivity.pro
+++ b/connectivity.pro
@@ -41,13 +41,13 @@ unix : !mac {
 
 	QMAKE_LIBDIR += lib $${PREFIX}/lib /opt/gsasl/lib
 	INCLUDEPATH += $${PREFIX}/include
-	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib64
+	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib/$$system(gcc -print-multiarch)
 	BOOST_PROGRAM_OPTIONS = boost_program_options boost_program_options-mt
 	BOOST_SYS = boost_system boost_system-mt
 
 
 	#
-	# searching in $PREFIX/lib and $PREFIX/lib64
+	# searching in $PREFIX/lib and $PREFIX/lib/$$system(gcc -print-multiarch)
 	# to override the default '/usr' pass PREFIX
 	# variable to qmake.
 	#

--- a/load.pro
+++ b/load.pro
@@ -42,14 +42,14 @@ unix : !mac {
 
 	QMAKE_LIBDIR += lib $${PREFIX}/lib /opt/gsasl/lib
 	INCLUDEPATH += $${PREFIX}/include
-	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib64
+	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib/$$system(gcc -print-multiarch)
 	BOOST_THREAD = boost_thread boost_thread-mt
 	BOOST_PROGRAM_OPTIONS = boost_program_options boost_program_options-mt
 	BOOST_SYS = boost_system boost_system-mt
 
 
 	#
-	# searching in $PREFIX/lib and $PREFIX/lib64
+	# searching in $PREFIX/lib and $PREFIX/lib/$$system(gcc -print-multiarch)
 	# to override the default '/usr' pass PREFIX
 	# variable to qmake.
 	#

--- a/pokerth_game.pro
+++ b/pokerth_game.pro
@@ -407,7 +407,7 @@ unix:!mac {
 	!android{
 		LIBPATH += $${PREFIX}/lib /opt/gsasl/lib
 		LIB_DIRS = $${PREFIX}/lib \
-			$${PREFIX}/lib64
+			$${PREFIX}/lib/$$system(gcc -print-multiarch)
 	}
 	android{
 		LIBPATH += $${PREFIX}/lib/armv7
@@ -426,7 +426,7 @@ unix:!mac {
 	BOOST_RANDOM = boost_random \
 		boost_random-mt
 
-	# searching in $PREFIX/lib and $PREFIX/lib64
+	# searching in $PREFIX/lib and $PREFIX/lib/$$system(gcc -print-multiarch)
 	# to override the default '/usr' pass PREFIX
 	# variable to qmake.
 	for(dir, LIB_DIRS):exists($$dir) {

--- a/pokerth_server.pro
+++ b/pokerth_server.pro
@@ -175,7 +175,7 @@ unix : !mac {
 
 	LIBPATH += lib $${PREFIX}/lib /opt/gsasl/lib
 	INCLUDEPATH += $${PREFIX}/include
-	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib64
+	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib/$$system(gcc -print-multiarch)
 	BOOST_FS = boost_filesystem boost_filesystem-mt
 	BOOST_THREAD = boost_thread boost_thread-mt
 	BOOST_PROGRAM_OPTIONS = boost_program_options boost_program_options-mt
@@ -185,7 +185,7 @@ unix : !mac {
 	BOOST_RANDOM = boost_random boost_random-mt
 
 	#
-	# searching in $PREFIX/lib and $PREFIX/lib64
+	# searching in $PREFIX/lib and $PREFIX/lib/$$system(gcc -print-multiarch)
 	# to override the default '/usr' pass PREFIX
 	# variable to qmake.
 	#

--- a/zlib_compress.pro
+++ b/zlib_compress.pro
@@ -48,7 +48,7 @@ unix : !mac {
 	#QMAKE_CXXFLAGS += -ffunction-sections -fdata-sections
 	#QMAKE_LFLAGS += -Wl,--gc-sections
 
-	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib64
+	LIB_DIRS = $${PREFIX}/lib $${PREFIX}/lib/$$system(gcc -print-multiarch)
 	BOOST_FS = boost_filesystem boost_filesystem-mt
 	BOOST_IOSTREAMS = boost_iostreams boost_iostreams-mt
 	BOOST_SYSTEM = boost_system boost_system-mt


### PR DESCRIPTION
do not look for libs in $${PREFIX}/lib64 but in $${PREFIX}/lib/$$system(gcc -print-multiarch)

that way we find libs in /usr/lib/x86_64-linux-gnu and other multiarch dirs on Debian-like systems.
