### PR TITLE
Show the winning hand after the round

### DIFF
--- a/src/gui/qt/gametable.ui
+++ b/src/gui/qt/gametable.ui
@@ -2222,13 +2222,13 @@ p, li { white-space: pre-wrap; }
         <property name="minimumSize">
          <size>
           <width>600</width>
-          <height>94</height>
+          <height>114</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
           <width>600</width>
-          <height>94</height>
+          <height>114</height>
          </size>
         </property>
         <property name="styleSheet">
@@ -2629,6 +2629,13 @@ p, li { white-space: pre-wrap; }
              </layout>
             </item>
            </layout>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="5">
+          <widget class="QLabel" name="label_WinningCombination">
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
           </widget>
          </item>
         </layout>

--- a/src/gui/qt/gametable/gametableimpl.cpp
+++ b/src/gui/qt/gametable/gametableimpl.cpp
@@ -2530,6 +2530,7 @@ void gameTableImpl::postRiverRunAnimation2()
 
 	if(nonfoldPlayersCounter!=1) {
 
+		label_WinningCombination->setText(CardsValue::determineHandName(currentGame->getCurrentHand()->getCurrentBeRo()->getHighestCardsValue(), activePlayerList).c_str());
 		if(!flipHolecardsAllInAlreadyDone) {
 
 			for (it_c=activePlayerList->begin(); it_c!=activePlayerList->end(); ++it_c) {
@@ -3017,6 +3018,8 @@ void gameTableImpl::nextRoundCleanGui()
 	resetMyButtonsCheckStateMemory();
 	clearMyButtons();
 	pushButton_showMyCards->hide();
+	label_WinningCombination->clear();
+	update();
 }
 
 void gameTableImpl::stopTimer()
@@ -4117,6 +4120,7 @@ void gameTableImpl::refreshGameTableStyle()
 	myGameTableStyle->setBigFontBoardStyle(textLabel_handLabel);
 	myGameTableStyle->setBigFontBoardStyle(label_Pot);
 #endif
+	myGameTableStyle->setBigFontBoardStyle(label_WinningCombination);
 	myGameTableStyle->setCardHolderStyle(label_CardHolder0,0);
 	myGameTableStyle->setCardHolderStyle(label_CardHolder1,0);
 	myGameTableStyle->setCardHolderStyle(label_CardHolder2,0);

--- a/src/gui/qt/gui_800x480/gametable_800x480.ui
+++ b/src/gui/qt/gui_800x480/gametable_800x480.ui
@@ -2745,13 +2745,13 @@ p, li { white-space: pre-wrap; }
         <property name="minimumSize">
          <size>
           <width>390</width>
-          <height>82</height>
+          <height>102</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
           <width>390</width>
-          <height>82</height>
+          <height>102</height>
          </size>
         </property>
         <property name="styleSheet">
@@ -3037,6 +3037,13 @@ p, li { white-space: pre-wrap; }
              <bool>true</bool>
             </property>
            </widget>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_WinningCombination">
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
           </widget>
          </item>
         </layout>


### PR DESCRIPTION
Fixes #306. Not tested on Android due to #375. Small note: in `gameTableImpl::nextRoundCleanGui()` we need to call `update()` to refresh the table, otherwise if fractional HiDPI scaling (QT_SCALE_FACTOR=1.2 in my case) is enabled some card leftovers stay on top of the card holders, it looks like a 1 pixel wide horizontal line:
![2020-01-12_16-06-33](https://user-images.githubusercontent.com/184066/72219285-85b5d500-3555-11ea-9230-f108a8ccc0f5.png)
The position of the line and its presence depends on the window aspect size, never happens if scaling (QT_SCALE_FACTOR env var) is disabled. Might be a Qt bug (I'm on 5.12.5) but this little workaround wouldn't hurt.