### PR TITLE
Remove setWindowFlags calls from dialogs to fix missing titlebars in Mac OS X

### DIFF
--- a/src/gui/qt/aboutpokerth/aboutpokerthimpl.cpp
+++ b/src/gui/qt/aboutpokerth/aboutpokerthimpl.cpp
@@ -45,7 +45,6 @@ aboutPokerthImpl::aboutPokerthImpl(QWidget *parent, ConfigFile *c)
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 

--- a/src/gui/qt/changecompleteblindsdialog/changecompleteblindsdialogimpl.cpp
+++ b/src/gui/qt/changecompleteblindsdialog/changecompleteblindsdialogimpl.cpp
@@ -39,7 +39,6 @@ changeCompleteBlindsDialogImpl::changeCompleteBlindsDialogImpl(QWidget *parent, 
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 	this->installEventFilter(this);

--- a/src/gui/qt/changecontentdialog/changecontentdialogimpl.cpp
+++ b/src/gui/qt/changecontentdialog/changecontentdialogimpl.cpp
@@ -39,7 +39,6 @@ changeContentDialogImpl::changeContentDialogImpl(QWidget *parent, ConfigFile *co
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 	this->installEventFilter(this);

--- a/src/gui/qt/connecttoserverdialog/connecttoserverdialogimpl.cpp
+++ b/src/gui/qt/connecttoserverdialog/connecttoserverdialogimpl.cpp
@@ -36,7 +36,6 @@ connectToServerDialogImpl::connectToServerDialogImpl(QWidget *parent)
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 #ifdef ANDROID

--- a/src/gui/qt/createinternetgamedialog/createinternetgamedialogimpl.cpp
+++ b/src/gui/qt/createinternetgamedialog/createinternetgamedialogimpl.cpp
@@ -40,7 +40,6 @@ createInternetGameDialogImpl::createInternetGameDialogImpl(QWidget *parent, Conf
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 	this->installEventFilter(this);

--- a/src/gui/qt/createnetworkgamedialog/createnetworkgamedialogimpl.cpp
+++ b/src/gui/qt/createnetworkgamedialog/createnetworkgamedialogimpl.cpp
@@ -38,7 +38,6 @@ createNetworkGameDialogImpl::createNetworkGameDialogImpl(QWidget *parent, Config
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 	this->installEventFilter(this);

--- a/src/gui/qt/gamelobbydialog/gamelobbydialogimpl.cpp
+++ b/src/gui/qt/gamelobbydialog/gamelobbydialogimpl.cpp
@@ -51,7 +51,6 @@ gameLobbyDialogImpl::gameLobbyDialogImpl(startWindowImpl *parent, ConfigFile *c)
 
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #elif _WIN32
 //	setWindowFlags(Qt::Dialog | Qt::WindowMinimizeButtonHint);
 #endif
@@ -66,9 +65,6 @@ gameLobbyDialogImpl::gameLobbyDialogImpl(startWindowImpl *parent, ConfigFile *c)
 #ifndef ANDROID
 	waitStartGameMsgBox->setWindowModality(Qt::NonModal);
 #endif
-#ifdef __APPLE__
-	waitStartGameMsgBox->setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
-#endif
 	waitStartGameMsgBox->setStandardButtons(QMessageBox::NoButton);
 
 	//wait start game message for rejoin
@@ -76,9 +72,6 @@ gameLobbyDialogImpl::gameLobbyDialogImpl(startWindowImpl *parent, ConfigFile *c)
 	waitRejoinStartGameMsgBox->setText(tr("Waiting for the start of the next hand to rejoin the game ..."));
 #ifndef ANDROID
 	waitRejoinStartGameMsgBox->setWindowModality(Qt::NonModal);
-#endif
-#ifdef __APPLE__
-	waitRejoinStartGameMsgBox->setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	waitRejoinStartGameMsgBox->setStandardButtons(QMessageBox::NoButton);
 

--- a/src/gui/qt/joinnetworkgamedialog/joinnetworkgamedialogimpl.cpp
+++ b/src/gui/qt/joinnetworkgamedialog/joinnetworkgamedialogimpl.cpp
@@ -42,7 +42,6 @@ joinNetworkGameDialogImpl::joinNetworkGameDialogImpl(QWidget *parent, ConfigFile
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 #ifdef ANDROID

--- a/src/gui/qt/mymessagedialog/mymessagedialogimpl.cpp
+++ b/src/gui/qt/mymessagedialog/mymessagedialogimpl.cpp
@@ -44,7 +44,6 @@ myMessageDialogImpl::myMessageDialogImpl(ConfigFile *c, QWidget *parent)
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 

--- a/src/gui/qt/newlocalgamedialog/newgamedialogimpl.cpp
+++ b/src/gui/qt/newlocalgamedialog/newgamedialogimpl.cpp
@@ -37,7 +37,6 @@ newGameDialogImpl::newGameDialogImpl(QMainWindow *parent, ConfigFile *c)
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 	this->installEventFilter(this);

--- a/src/gui/qt/serverlistdialog/serverlistdialogimpl.cpp
+++ b/src/gui/qt/serverlistdialog/serverlistdialogimpl.cpp
@@ -40,7 +40,6 @@ serverListDialogImpl::serverListDialogImpl(startWindowImpl *sw, QMainWindow *par
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 #ifdef ANDROID

--- a/src/gui/qt/settingsdialog/manualblindsorderdialog/manualblindsorderdialogimpl.cpp
+++ b/src/gui/qt/settingsdialog/manualblindsorderdialog/manualblindsorderdialogimpl.cpp
@@ -39,7 +39,6 @@ manualBlindsOrderDialogImpl::manualBlindsOrderDialogImpl(QWidget *parent, Config
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 #ifdef ANDROID

--- a/src/gui/qt/settingsdialog/selectavatardialog/selectavatardialogimpl.cpp
+++ b/src/gui/qt/settingsdialog/selectavatardialog/selectavatardialogimpl.cpp
@@ -40,7 +40,6 @@ selectAvatarDialogImpl::selectAvatarDialogImpl(QWidget *parent, ConfigFile *c)
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 #ifdef ANDROID

--- a/src/gui/qt/settingsdialog/settingsdialogimpl.cpp
+++ b/src/gui/qt/settingsdialog/settingsdialogimpl.cpp
@@ -45,7 +45,6 @@ settingsDialogImpl::settingsDialogImpl(QWidget *parent, ConfigFile *c, selectAva
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 

--- a/src/gui/qt/startnetworkgamedialog/startnetworkgamedialogimpl.cpp
+++ b/src/gui/qt/startnetworkgamedialog/startnetworkgamedialogimpl.cpp
@@ -41,7 +41,6 @@ startNetworkGameDialogImpl::startNetworkGameDialogImpl(startWindowImpl *parent, 
 {
 #ifdef __APPLE__
 	setWindowModality(Qt::ApplicationModal);
-	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 #endif
 	setupUi(this);
 #ifdef ANDROID

--- a/src/gui/qt/startwindow/startwindowimpl.cpp
+++ b/src/gui/qt/startwindow/startwindowimpl.cpp
@@ -83,7 +83,6 @@ startWindowImpl::startWindowImpl(ConfigFile *c, Log *l)
 
 	// #ifdef __APPLE__
 	// 	setWindowModality(Qt::ApplicationModal);
-	// 	setWindowFlags(Qt::WindowSystemMenuHint | Qt::CustomizeWindowHint | Qt::Dialog);
 	// #endif
 	setupUi(this);
 	this->setWindowTitle(QString(tr("PokerTH %1").arg(POKERTH_BETA_RELEASE_STRING)));


### PR DESCRIPTION
The calls to `setWindowFlags` caused the title bar to not be shown on dialog, making it impossible to move the windows around with the mouse (very, very annoying!!!). Removing them altogether fixes that.

Apart from that, my knowledge about Qt is still not very good, so I am not sure what the other flags are for.