### PR TITLE
Use <boost/bind/bind.hpp> inclusion and namespace boost::placeholders

### DIFF
--- a/src/db/common/serverdbgeneric.cpp
+++ b/src/db/common/serverdbgeneric.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <db/serverdbgeneric.h>
 
 using namespace std;

--- a/src/dbofficial/asyncdbauth.cpp
+++ b/src/dbofficial/asyncdbauth.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdbauth.h>
 
 

--- a/src/dbofficial/asyncdbavatarblacklist.cpp
+++ b/src/dbofficial/asyncdbavatarblacklist.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdbavatarblacklist.h>
 
 

--- a/src/dbofficial/asyncdbblockplayer.cpp
+++ b/src/dbofficial/asyncdbblockplayer.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdbblockplayer.h>
 #include <dbofficial/dbidmanager.h>
 

--- a/src/dbofficial/asyncdbcreategame.cpp
+++ b/src/dbofficial/asyncdbcreategame.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdbcreategame.h>
 #include <dbofficial/dbidmanager.h>
 

--- a/src/dbofficial/asyncdbgameplace.cpp
+++ b/src/dbofficial/asyncdbgameplace.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdbgameplace.h>
 #include <dbofficial/dbidmanager.h>
 

--- a/src/dbofficial/asyncdblogin.cpp
+++ b/src/dbofficial/asyncdblogin.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdblogin.h>
 
 

--- a/src/dbofficial/asyncdbreportavatar.cpp
+++ b/src/dbofficial/asyncdbreportavatar.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdbreportavatar.h>
 
 

--- a/src/dbofficial/asyncdbreportgame.cpp
+++ b/src/dbofficial/asyncdbreportgame.cpp
@@ -29,7 +29,7 @@
  * as that of the covered work.                                              *
  *****************************************************************************/
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <dbofficial/asyncdbreportgame.h>
 #include <dbofficial/dbidmanager.h>
 

--- a/src/net/common/asioreceivebuffer.cpp
+++ b/src/net/common/asioreceivebuffer.cpp
@@ -30,7 +30,7 @@
  *****************************************************************************/
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <net/asioreceivebuffer.h>
 #include <net/sessiondata.h>

--- a/src/net/common/asiosendbuffer.cpp
+++ b/src/net/common/asiosendbuffer.cpp
@@ -30,7 +30,7 @@
  *****************************************************************************/
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <net/asiosendbuffer.h>
 #include <net/sessiondata.h>

--- a/src/net/common/chatcleanermanager.cpp
+++ b/src/net/common/chatcleanermanager.cpp
@@ -31,7 +31,7 @@
 
 #include <net/chatcleanermanager.h>
 #include <net/asiosendbuffer.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <core/loghelper.h>
 #include <third_party/protobuf/chatcleaner.pb.h>
 

--- a/src/net/common/clientstate.cpp
+++ b/src/net/common/clientstate.cpp
@@ -46,7 +46,7 @@
 #include <playerinterface.h>
 
 #include <tinyxml.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/foreach.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>

--- a/src/net/common/serveradminbot.cpp
+++ b/src/net/common/serveradminbot.cpp
@@ -39,7 +39,7 @@
 #include <core/loghelper.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #define SERVER_RESTART_IRC_BOT_INTERVAL_SEC			86400	// 1 day

--- a/src/net/common/servergame.cpp
+++ b/src/net/common/servergame.cpp
@@ -30,7 +30,7 @@
  *****************************************************************************/
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <algorithm>
 
 #include <net/servergame.h>

--- a/src/net/common/servergamestate.cpp
+++ b/src/net/common/servergamestate.cpp
@@ -46,7 +46,7 @@
 #include <playerinterface.h>
 #include <handinterface.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 
@@ -986,7 +986,7 @@ ServerGameStateHand::EngineLoop(boost::shared_ptr<ServerGame> server)
 
 		// Retrieve non-fold players. If only one player is left, no cards are shown.
 		list<boost::shared_ptr<PlayerInterface> > nonFoldPlayers = *curGame.getActivePlayerList();
-		nonFoldPlayers.remove_if(boost::bind(&PlayerInterface::getMyAction, _1) == PLAYER_ACTION_FOLD);
+		nonFoldPlayers.remove_if(boost::bind(&PlayerInterface::getMyAction, boost::placeholders::_1) == PLAYER_ACTION_FOLD);
 
 		if (curGame.getCurrentHand()->getAllInCondition()
 				&& !curGame.getCurrentHand()->getCardsShown()
@@ -1076,7 +1076,7 @@ ServerGameStateHand::EngineLoop(boost::shared_ptr<ServerGame> server)
 
 			// Retrieve non-fold players. If only one player is left, no cards are shown.
 			list<boost::shared_ptr<PlayerInterface> > nonFoldPlayers = *curGame.getActivePlayerList();
-			nonFoldPlayers.remove_if(boost::bind(&PlayerInterface::getMyAction, _1) == PLAYER_ACTION_FOLD);
+			nonFoldPlayers.remove_if(boost::bind(&PlayerInterface::getMyAction, boost::placeholders::_1) == PLAYER_ACTION_FOLD);
 
 			if (nonFoldPlayers.size() == 1) {
 				// End of Hand, but keep cards hidden.
@@ -1119,7 +1119,7 @@ ServerGameStateHand::EngineLoop(boost::shared_ptr<ServerGame> server)
 
 			// Start next hand - if enough players are left.
 			list<boost::shared_ptr<PlayerInterface> > playersWithCash = *curGame.getActivePlayerList();
-			playersWithCash.remove_if(boost::bind(&PlayerInterface::getMyCash, _1) < 1);
+			playersWithCash.remove_if(boost::bind(&PlayerInterface::getMyCash, boost::placeholders::_1) < 1);
 
 			if (playersWithCash.empty()) {
 				// No more players left - restart.

--- a/src/net/common/serverlobbybot.cpp
+++ b/src/net/common/serverlobbybot.cpp
@@ -38,7 +38,7 @@
 #include <net/socket_startup.h>
 #include <core/loghelper.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #define SERVER_RESTART_IRC_BOT_INTERVAL_SEC			86400	// 1 day

--- a/src/net/common/serverlobbythread.cpp
+++ b/src/net/common/serverlobbythread.cpp
@@ -57,7 +57,7 @@
 #include <cctype>
 #include <boost/lambda/lambda.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/foreach.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/algorithm/string.hpp>

--- a/src/net/common/servermanager.cpp
+++ b/src/net/common/servermanager.cpp
@@ -41,7 +41,7 @@
 #include <net/serverircbotcallback.h>
 #include <core/loghelper.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 using namespace std;


### PR DESCRIPTION
Fix warning:

/usr/include/boost/bind.hpp:36:1: note: ‘#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~