### PR TITLE
asioreceivebuffer.cpp: AA_EnableHighDpiScaling’ is deprecated with Qt6

### DIFF
--- a/src/net/common/asioreceivebuffer.cpp
+++ b/src/net/common/asioreceivebuffer.cpp
@@ -35,7 +35,6 @@
 #include <net/asioreceivebuffer.h>
 #include <net/sessiondata.h>
 #include <core/loghelper.h>
-#include <boost/swap.hpp>
 
 using namespace std;
 


### PR DESCRIPTION
/pokerth/src/pokerth.cpp:106:40: warning: ‘Qt::AA_EnableHighDpiScaling’ is deprecated: High-DPI scaling is always enabled. This attribute no longer has any effect. [-Wdeprecated-declarations]
  106 |         QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);