### PR TITLE
pokerth.cpp: AA_EnableHighDpiScaling’ is deprecated with Qt6

### DIFF
--- a/src/pokerth.cpp
+++ b/src/pokerth.cpp
@@ -103,7 +103,9 @@ int main( int argc, char **argv )
 	QApplication a(argc, argv);
 	a.setApplicationName("PokerTH");
 #else
-	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	#if QT_VERSION < 0x060000
+		QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	# endif
 	SharedTools::QtSingleApplication a( "PokerTH", argc, argv );
 	if (a.sendMessage("Wake up!")) {
 		return 0;


### PR DESCRIPTION
Fix warning:

/pokerth/src/pokerth.cpp:106:40: warning: ‘Qt::AA_EnableHighDpiScaling’ is deprecated: High-DPI scaling is always enabled. This attribute no longer has any effect. [-Wdeprecated-declarations] 106 | QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);