### PR TITLE
clientstate.cpp: Use <boost/bind/bind.hpp> inclusion

### DIFF
--- a/src/net/common/clientstate.cpp
+++ b/src/net/common/clientstate.cpp
@@ -50,7 +50,7 @@
 #include <QDomNode>
 #include <QDebug>
 #include <QFile>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/foreach.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>


### PR DESCRIPTION
Fix warning:

/usr/include/boost/bind.hpp:36:1: note: ‘#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~