### PR TITLE
chattools.cpp: Use nullptr instead of NULL

### DIFF
--- a/src/gui/qt/chattools/chattools.cpp
+++ b/src/gui/qt/chattools/chattools.cpp
@@ -40,7 +40,7 @@
 using namespace std;
 
 
-ChatTools::ChatTools(QLineEdit* l, ConfigFile *c, ChatType ct, QTextBrowser *b, QStandardItemModel *m, gameLobbyDialogImpl *lo) : nickAutoCompletitionCounter(0), myLineEdit(l), myNickListModel(m), myNickStringList(NULL), myTextBrowser(b), myChatType(ct), myConfig(c), myNick(""), myLobby(lo)
+ChatTools::ChatTools(QLineEdit* l, ConfigFile *c, ChatType ct, QTextBrowser *b, QStandardItemModel *m, gameLobbyDialogImpl *lo) : nickAutoCompletitionCounter(0), myLineEdit(l), myNickListModel(m), myNickStringList(nullptr), myTextBrowser(b), myChatType(ct), myConfig(c), myNick(""), myLobby(lo)
 {
 	myNick = QString::fromUtf8(myConfig->readConfigString("MyName").c_str());
 	ignoreList = myConfig->readConfigStringList("PlayerIgnoreList");


### PR DESCRIPTION
Fix warning:

pokerth/src/gui/qt/chattools/chattools.cpp:43:215: warning: passing NULL to non-pointer argument 1 of ‘QList<T>......... [-Wconversion-null] 43 | ls(QLineEdit* l, ConfigFile *c, ChatType ct, QTextBrowse............ myLineEdit(l), myNickListModel(m), myNickStringList(NULL), myTex
                                                                                                                              ^~~~