### PR TITLE
Create desktop file for qt6_qml client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,8 @@ if(BUILD_CLIENT)
 
         install(TARGETS pokerth_client DESTINATION /usr/bin)
         install(DIRECTORY data DESTINATION /usr/share/pokerth)
+        install(FILES pokerth.desktop DESTINATION /usr/share/applications)
+        install(FILES pokerth.png DESTINATION /usr/share/pixmaps)
     else()
         # BUILD_QML_CLIENT
         add_definitions(-DQML_CLIENT)
@@ -468,6 +470,8 @@ if(BUILD_CLIENT)
 
         install(TARGETS pokerth_qml-client DESTINATION /usr/bin)
         install(DIRECTORY data DESTINATION /usr/share/pokerth)
+        install(FILES pokerth_qml.desktop DESTINATION /usr/share/applications)
+        install(FILES pokerth.png DESTINATION /usr/share/pixmaps)
     endif()
 else()
     # build deicated server

--- a/pokerth_qml.desktop
+++ b/pokerth_qml.desktop
@@ -38,7 +38,7 @@ Comment[pt_PT]=Jogo do Texas Hol'dem
 Comment[ru]=Игра в техасский холдем
 Comment[tr]=Texas hold'em oyunu
 Comment[uk]=Гра в техаський холдем
-Exec=env QT_SCALE_FACTOR=1 pokerth_client
+Exec=env QT_SCALE_FACTOR=1 pokerth_qml-client
 Icon=pokerth
 Terminal=false
 Type=Application


### PR DESCRIPTION
-Use pokerth_client as binary name for client in desktop file. -Install desktop files and png file as well.

This fixes that Pokerth didn't appear in 'Show apps" sidebar Ubuntu. And fix missing icon for sidebar and desktop shortcut (unless you still have the old files before the Cmake transition).