### PR TITLE
Fix the build of chatcleaner with Qt 6.10 (fixes #489)

### DIFF
--- a/src/chatcleaner/cleanerserver.cpp
+++ b/src/chatcleaner/cleanerserver.cpp
@@ -195,7 +195,7 @@ bool CleanerServer::handleMessage(ChatCleanerMessage &msg)
 				netReply->set_cleaneractiontype(CleanerChatReplyMessage_CleanerActionType_cleanerActionMute);
 			}
 
-			netReply->set_cleanertext(checkMessage.toUtf8());
+			netReply->set_cleanertext(static_cast<const char *>(checkMessage.toUtf8()));
 			sendMessageToClient(*tmpReply);
 		}
 	}


### PR DESCRIPTION
This fixes the issue reported in #489 with an explicit cast to `const char *`, which I believe was the implicit conversion being used before.  It builds fine with Qt 6.10.1 with this applied.

_Edit:_ I only use PokerTH locally so I'm not sure what's needed to test this code path.