### PR TITLE
Add missing player set resets in the network client (fixes #491)

### DIFF
--- a/src/net/clientstate.cpp
+++ b/src/net/clientstate.cpp
@@ -2208,6 +2208,7 @@ ClientStateRunHand::InternalHandlePacket(boost::shared_ptr<ClientThread> client,
 		curGame->getCurrentHand()->getBoard()->setMyCards(tmpCards);
 		curGame->getCurrentHand()->getBoard()->collectPot();
 		curGame->getCurrentHand()->setPreviousPlayerID(-1);
+		ResetPlayerSets(*curGame);
 
 		client->GetGui().logDealBoardCardsMsg(GAME_STATE_FLOP, tmpCards[0], tmpCards[1], tmpCards[2], tmpCards[3], tmpCards[4]);
 		client->GetClientLog()->setCurrentRound(GAME_STATE_FLOP);
@@ -2225,6 +2226,7 @@ ClientStateRunHand::InternalHandlePacket(boost::shared_ptr<ClientThread> client,
 		curGame->getCurrentHand()->getBoard()->setMyCards(tmpCards);
 		curGame->getCurrentHand()->getBoard()->collectPot();
 		curGame->getCurrentHand()->setPreviousPlayerID(-1);
+		ResetPlayerSets(*curGame);
 
 		client->GetGui().logDealBoardCardsMsg(GAME_STATE_TURN, tmpCards[0], tmpCards[1], tmpCards[2], tmpCards[3], tmpCards[4]);
 		client->GetClientLog()->setCurrentRound(GAME_STATE_TURN);
@@ -2242,6 +2244,7 @@ ClientStateRunHand::InternalHandlePacket(boost::shared_ptr<ClientThread> client,
 		curGame->getCurrentHand()->getBoard()->setMyCards(tmpCards);
 		curGame->getCurrentHand()->getBoard()->collectPot();
 		curGame->getCurrentHand()->setPreviousPlayerID(-1);
+		ResetPlayerSets(*curGame);
 
 		client->GetGui().logDealBoardCardsMsg(GAME_STATE_RIVER, tmpCards[0], tmpCards[1], tmpCards[2], tmpCards[3], tmpCards[4]);
 		client->GetClientLog()->setCurrentRound(GAME_STATE_RIVER);
@@ -2401,7 +2404,7 @@ ClientStateRunHand::ResetPlayerSets(Game &curGame)
     PlayerListIterator i = curGame.getActivePlayerList()->begin();
     PlayerListIterator end = curGame.getActivePlayerList()->end();
     while (i != end) {
-        (*i)->setMySet(0);
+        (*i)->setMySetNull();
         ++i;
     }
 }


### PR DESCRIPTION
This is based on very light reading of src/net/.  I see calls to `ClientStateRunHand::ResetPlayerSets()` for messages `PokerTHMessage::Type_EndOfHand{Show,Hide}CardsMessage`, but nothing I can see in the flop/turn/river code resets the player sets back to zero.  Additionally, maybe `ResetPlayerSets()` should be calling `setMySetNull()`, not just `setMySet(0)`, so that `mySet` also, not just `myLastRelativeSet`, is set back to 0.

Both of these changes together fix the crash for me and the game appears to run fine afterward.  But I'm new to the code base so it's possible I'm totally misunderstanding how this is supposed to work.