### PR TITLE
Follow up build fix for OpenBSD

### DIFF
--- a/src/net/clientstate.cpp
+++ b/src/net/clientstate.cpp
@@ -623,19 +623,17 @@ ClientStateStartConnect::HandleConnect(const boost::system::error_code& ec, boos
                     }
 #else
                     // Linux / macOS: per-socket keepalive tuning
+#if defined(TCP_KEEPALIVE) || defined(TCP_KEEPIDLE)
                     int keepidle  = 30;   // seconds until first keepalive probe
                     int keepintvl = 10;   // seconds between subsequent probes
                     int keepcnt   = 6;    // failed probes before disconnect
-#if defined(TCP_KEEPALIVE) || defined(TCP_KEEPIDLE)
 #ifdef TCP_KEEPALIVE
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle,  sizeof(keepidle));
-                    setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
-                    setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,   &keepcnt,   sizeof(keepcnt));
 #else
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,  &keepidle,  sizeof(keepidle));
+#endif
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,   &keepcnt,   sizeof(keepcnt));
-#endif
 #endif
                     // TCP_USER_TIMEOUT: abort connection if sent data remains
                     // unacknowledged for 90s (matches keepalive detection time).

--- a/src/net/serveraccepthelper.h
+++ b/src/net/serveraccepthelper.h
@@ -242,18 +242,18 @@ protected:
                     }
 #else
                     // Linux / macOS: per-socket keepalive tuning
+#if defined(TCP_KEEPALIVE) || defined(TCP_KEEPIDLE)
                     int keepidle  = 30;   // seconds until first keepalive probe
                     int keepintvl = 10;   // seconds between subsequent probes
                     int keepcnt   = 6;    // number of failed probes before disconnect
-#if defined(TCP_KEEPALIVE) || defined(TCP_KEEPIDLE)
 #ifdef TCP_KEEPALIVE
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle,  sizeof(keepidle));
 #else
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,  &keepidle,  sizeof(keepidle));
 #endif
-#endif
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
                     setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,   &keepcnt,   sizeof(keepcnt));
+#endif
                     // TCP_USER_TIMEOUT: abort connection if data remains
                     // unacknowledged for 90s (matches keepalive detection).
                     // Without this, a dead client can keep the server


### PR DESCRIPTION
- Move the #endif down two lines
- Deduplicate the TCP_KEEPINTVL / TCP_KEEPCNT lines in the client code
  as is done with the server code
- Move the TCP_KEEPALIVE / TCP_KEEPIDLE checks up as the variables are
  defined but not used otherwise