### PR TITLE
Limit WebSocket message buffering

### DIFF
--- a/src/net/netpacket.h
+++ b/src/net/netpacket.h
@@ -47,6 +47,9 @@
 #define MAX_FILE_DATA_SIZE			256
 #define MAX_PACKET_SIZE				384
 #define MAX_CHAT_TEXT_SIZE			128
+// WebSocket messages can carry multiple length-prefixed packets, but must not
+// inherit WebSocket++'s 32 MB default allocation limit.
+#define MAX_WEBSOCKET_MESSAGE_SIZE	16384
 
 /*#define MIN_PACKET_SIZE				4
 #define MAX_NAME_SIZE				64
@@ -91,4 +94,3 @@ private:
 typedef std::list<boost::shared_ptr<NetPacket> > NetPacketList;
 
 #endif
-

--- a/src/net/serveracceptwebhelper.cpp
+++ b/src/net/serveracceptwebhelper.cpp
@@ -67,6 +67,7 @@ ServerAcceptWebHelper::Listen(unsigned serverPort, bool /*ipv6*/, const std::str
 #endif
 
 		m_webSocketTlsServer->init_asio(m_ioService.get());
+		m_webSocketTlsServer->set_max_message_size(MAX_WEBSOCKET_MESSAGE_SIZE);
 
 		m_webSocketTlsServer->set_validate_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::validate), this, boost::placeholders::_1));
 		m_webSocketTlsServer->set_open_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::on_open), this, boost::placeholders::_1));
@@ -85,6 +86,7 @@ ServerAcceptWebHelper::Listen(unsigned serverPort, bool /*ipv6*/, const std::str
 #endif
 
 		m_webSocketServer->init_asio(m_ioService.get());
+		m_webSocketServer->set_max_message_size(MAX_WEBSOCKET_MESSAGE_SIZE);
 
 		m_webSocketServer->set_validate_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::validate), this, boost::placeholders::_1));
 		m_webSocketServer->set_open_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::on_open), this, boost::placeholders::_1));

--- a/src/net/webreceivebuffer.cpp
+++ b/src/net/webreceivebuffer.cpp
@@ -56,6 +56,16 @@ WebReceiveBuffer::HandleRead(boost::shared_ptr<SessionData> /*session*/, const b
 void
 WebReceiveBuffer::HandleMessage(boost::shared_ptr<SessionData> session, const string &msg)
 {
+	// Keep the application-level limit in force even if the endpoint setting is
+	// changed in the future.  Without this, legacy framing hands the complete
+	// WebSocket message directly to protobuf parsing.
+	if (msg.size() > MAX_WEBSOCKET_MESSAGE_SIZE) {
+		LOG_ERROR("Session " << session->GetId() << " - WebSocket message exceeds "
+				  << MAX_WEBSOCKET_MESSAGE_SIZE << " bytes - closing connection");
+		session->Close();
+		return;
+	}
+
 	boost::shared_ptr<WebSocketData> webData = session->GetWebData();
 	if (webData && webData->lengthPrefixed) {
 		// Length-prefixed framing: do not rely on websocket message boundaries.
@@ -114,4 +124,3 @@ WebReceiveBuffer::ProcessPacket(boost::shared_ptr<SessionData> session, const ch
 		session->HandlePacket(tmpPacket);
 	}
 }
-


### PR DESCRIPTION
Legacy WebSocket traffic enters `WebReceiveBuffer::HandleMessage` without the game’s packet-size guard, so WebSocket++ can buffer its 32 MB default before protobuf validation.

Set a 16 KiB endpoint limit for TLS and non-TLS connections in `ServerAcceptWebHelper`, then recheck it in `WebReceiveBuffer` before parsing. This still permits coalesced length-prefixed packets while bounding per-connection buffering.