### PR TITLE
Harden chat cleaner connection admission

### DIFF
--- a/src/chatcleaner/cleanerconfig.cpp
+++ b/src/chatcleaner/cleanerconfig.cpp
@@ -127,7 +127,7 @@ CleanerConfig::CleanerConfig()
 	configList.push_back(ConfigInfo("ConfigRevision", CONFIG_TYPE_INT, tempIntToString.str()));
 	configList.push_back(ConfigInfo("Language", CONFIG_TYPE_STRING, getDefaultLanguage()));
 
-	configList.push_back(ConfigInfo("HostAddress", CONFIG_TYPE_STRING, "0.0.0.0"));
+	configList.push_back(ConfigInfo("HostAddress", CONFIG_TYPE_STRING, "127.0.0.1"));
 	configList.push_back(ConfigInfo("DefaultListenPort", CONFIG_TYPE_STRING, "4327"));
 	configList.push_back(ConfigInfo("ClientAuthString", CONFIG_TYPE_STRING, ""));
 	configList.push_back(ConfigInfo("ServerAuthString", CONFIG_TYPE_STRING, ""));

--- a/src/chatcleaner/cleanerserver.cpp
+++ b/src/chatcleaner/cleanerserver.cpp
@@ -42,7 +42,7 @@
 
 using namespace std;
 
-CleanerServer::CleanerServer(): config(0), blockConnection(false), m_recvBufUsed(0), secondsSinceLastConfigChange(0)
+CleanerServer::CleanerServer(): tcpServer(0), tcpSocket(0), configRefreshTimer(0), authenticationTimer(0), myMessageFilter(0), config(0), blockConnection(false), authenticated(false), m_recvBufUsed(0), secondsSinceLastConfigChange(0)
 {
 	config = new CleanerConfig;
 
@@ -60,8 +60,11 @@ CleanerServer::CleanerServer(): config(0), blockConnection(false), m_recvBufUsed
 	qDebug() << QString("The server is running on port %1.").arg(tcpServer->serverPort());
 
 	configRefreshTimer = new QTimer();
+	authenticationTimer = new QTimer();
+	authenticationTimer->setSingleShot(true);
 
 	connect(configRefreshTimer, SIGNAL(timeout()), this, SLOT(refreshConfig()));
+	connect(authenticationTimer, SIGNAL(timeout()), this, SLOT(authenticationTimedOut()));
 	connect(tcpServer, SIGNAL(newConnection()), this, SLOT(newCon()));
 
 	refreshConfig();
@@ -74,16 +77,31 @@ CleanerServer::~CleanerServer()
 	delete myMessageFilter;
 	delete tcpServer;
 	delete configRefreshTimer;
+	delete authenticationTimer;
 }
 
 void CleanerServer::newCon()
 {
 	if(!blockConnection) {
 		tcpSocket = tcpServer->nextPendingConnection();
+		if (!tcpSocket)
+			return;
 		connect(tcpSocket, SIGNAL(readyRead()), this, SLOT(onRead()));
 		connect(tcpSocket, SIGNAL(stateChanged(QAbstractSocket::SocketState)), this, SLOT(socketStateChanged(QAbstractSocket::SocketState)));
 		blockConnection = true;
+		authenticated = false;
 		tcpServer->pauseAccepting();
+
+		// Remote deployments must configure both shared secrets.  The local
+		// default keeps compatibility with existing same-host installations.
+		if (!tcpSocket->peerAddress().isLoopback()
+				&& (clientSecret.isEmpty() || serverSecret.isEmpty())) {
+			qDebug() << "Rejecting remote chat cleaner client without configured secrets.";
+			tcpSocket->close();
+			return;
+		}
+
+		authenticationTimer->start(CLEANER_AUTH_TIMEOUT_MSEC);
 	}
 }
 
@@ -152,6 +170,8 @@ bool CleanerServer::handleMessage(ChatCleanerMessage &msg)
 		const CleanerInitMessage &netInit = msg.cleanerinitmessage();
 		if (netInit.requestedversion() == CLEANER_PROTOCOL_VERSION) {
 			if (clientSecret == QString::fromStdString(netInit.clientsecret())) {
+				authenticated = true;
+				authenticationTimer->stop();
 				error = false;
 
 				boost::shared_ptr<ChatCleanerMessage> tmpAck(ChatCleanerMessage::default_instance().New());
@@ -164,7 +184,7 @@ bool CleanerServer::handleMessage(ChatCleanerMessage &msg)
 				qDebug() << "Invalid client secret.";
 		} else
 			qDebug() << "Invalid client version: " << netInit.requestedversion();
-	} else if (msg.messagetype() == ChatCleanerMessage::Type_CleanerChatRequestMessage) {
+	} else if (msg.messagetype() == ChatCleanerMessage::Type_CleanerChatRequestMessage && authenticated) {
 		error = false;
 		const CleanerChatRequestMessage &netRequest = msg.cleanerchatrequestmessage();
 		unsigned playerId = netRequest.playerid();
@@ -198,6 +218,8 @@ bool CleanerServer::handleMessage(ChatCleanerMessage &msg)
 			netReply->set_cleanertext(static_cast<const char *>(checkMessage.toUtf8()));
 			sendMessageToClient(*tmpReply);
 		}
+	} else if (msg.messagetype() == ChatCleanerMessage::Type_CleanerChatRequestMessage) {
+		qDebug() << "Rejected unauthenticated chat cleaner request.";
 	}
 	return error;
 }
@@ -206,8 +228,18 @@ void CleanerServer::socketStateChanged(QAbstractSocket::SocketState state)
 {
 	qDebug() << "Socket state changed to: " << state;
 	if (state == QAbstractSocket::UnconnectedState) {
+		authenticationTimer->stop();
 		blockConnection = false;
+		authenticated = false;
 		tcpServer->resumeAccepting();
+	}
+}
+
+void CleanerServer::authenticationTimedOut()
+{
+	if (blockConnection && !authenticated && tcpSocket) {
+		qDebug() << "Chat cleaner client did not authenticate in time.";
+		tcpSocket->close();
 	}
 }
 
@@ -232,4 +264,3 @@ void CleanerServer::sendMessageToClient(ChatCleanerMessage &msg)
 	tcpSocket->write((const char *)buf, packetSize + CLEANER_NET_HEADER_SIZE);
 	delete[] buf;
 }
-

--- a/src/chatcleaner/cleanerserver.h
+++ b/src/chatcleaner/cleanerserver.h
@@ -37,6 +37,7 @@
 #define CLEANER_NET_HEADER_SIZE		4
 #define MAX_CLEANER_PACKET_SIZE		512
 #define CLEANER_PROTOCOL_VERSION	2
+#define CLEANER_AUTH_TIMEOUT_MSEC	5000
 
 class MessageFilter;
 class CleanerConfig;
@@ -55,6 +56,7 @@ private slots:
 	void onRead();
 	bool handleMessage(ChatCleanerMessage &msg);
 	void socketStateChanged(QAbstractSocket::SocketState);
+	void authenticationTimedOut();
 	void refreshConfig();
 	void sendMessageToClient(ChatCleanerMessage &msg);
 
@@ -62,10 +64,12 @@ private:
 	QTcpServer *tcpServer;
 	QTcpSocket *tcpSocket;
 	QTimer *configRefreshTimer;
+	QTimer *authenticationTimer;
 	MessageFilter *myMessageFilter;
 
 	CleanerConfig *config;
 	bool blockConnection;
+	bool authenticated;
 	QString clientSecret;
 	QString serverSecret;
 

--- a/src/net/netpacket.h
+++ b/src/net/netpacket.h
@@ -47,6 +47,9 @@
 #define MAX_FILE_DATA_SIZE			256
 #define MAX_PACKET_SIZE				384
 #define MAX_CHAT_TEXT_SIZE			128
+// WebSocket messages can carry multiple length-prefixed packets, but must not
+// inherit WebSocket++'s 32 MB default allocation limit.
+#define MAX_WEBSOCKET_MESSAGE_SIZE	16384
 
 /*#define MIN_PACKET_SIZE				4
 #define MAX_NAME_SIZE				64
@@ -91,4 +94,3 @@ private:
 typedef std::list<boost::shared_ptr<NetPacket> > NetPacketList;
 
 #endif
-

--- a/src/net/serveracceptwebhelper.cpp
+++ b/src/net/serveracceptwebhelper.cpp
@@ -67,6 +67,7 @@ ServerAcceptWebHelper::Listen(unsigned serverPort, bool /*ipv6*/, const std::str
 #endif
 
 		m_webSocketTlsServer->init_asio(m_ioService.get());
+		m_webSocketTlsServer->set_max_message_size(MAX_WEBSOCKET_MESSAGE_SIZE);
 
 		m_webSocketTlsServer->set_validate_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::validate), this, boost::placeholders::_1));
 		m_webSocketTlsServer->set_open_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::on_open), this, boost::placeholders::_1));
@@ -85,6 +86,7 @@ ServerAcceptWebHelper::Listen(unsigned serverPort, bool /*ipv6*/, const std::str
 #endif
 
 		m_webSocketServer->init_asio(m_ioService.get());
+		m_webSocketServer->set_max_message_size(MAX_WEBSOCKET_MESSAGE_SIZE);
 
 		m_webSocketServer->set_validate_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::validate), this, boost::placeholders::_1));
 		m_webSocketServer->set_open_handler(boost::bind(boost::mem_fn(&ServerAcceptWebHelper::on_open), this, boost::placeholders::_1));

--- a/src/net/webreceivebuffer.cpp
+++ b/src/net/webreceivebuffer.cpp
@@ -56,6 +56,16 @@ WebReceiveBuffer::HandleRead(boost::shared_ptr<SessionData> /*session*/, const b
 void
 WebReceiveBuffer::HandleMessage(boost::shared_ptr<SessionData> session, const string &msg)
 {
+	// Keep the application-level limit in force even if the endpoint setting is
+	// changed in the future.  Without this, legacy framing hands the complete
+	// WebSocket message directly to protobuf parsing.
+	if (msg.size() > MAX_WEBSOCKET_MESSAGE_SIZE) {
+		LOG_ERROR("Session " << session->GetId() << " - WebSocket message exceeds "
+				  << MAX_WEBSOCKET_MESSAGE_SIZE << " bytes - closing connection");
+		session->Close();
+		return;
+	}
+
 	boost::shared_ptr<WebSocketData> webData = session->GetWebData();
 	if (webData && webData->lengthPrefixed) {
 		// Length-prefixed framing: do not rely on websocket message boundaries.
@@ -114,4 +124,3 @@ WebReceiveBuffer::ProcessPacket(boost::shared_ptr<SessionData> session, const ch
 		session->HandlePacket(tmpPacket);
 	}
 }
-


### PR DESCRIPTION
`CleanerServer::newCon` accepts one TCP client and pauses further accepts. A peer that connects but never sends an init message can keep that slot occupied.

Bind new configurations to loopback. For explicit remote bindings, reject empty shared secrets and close clients that do not authenticate within five seconds. `handleMessage` also rejects chat requests until authentication completes.