### PR TITLE
Bound WebSocket send queue memory

### DIFF
--- a/src/net/websendbuffer.cpp
+++ b/src/net/websendbuffer.cpp
@@ -36,6 +36,8 @@
 
 using namespace std;
 
+// Keep the same one MiB per-session send backlog used by AsioSendBuffer.
+#define MAX_WEBSOCKET_SEND_QUEUE_SIZE (1024 * 1024)
 
 WebSendBuffer::WebSendBuffer()
 	: closeAfterSend(false)
@@ -68,6 +70,11 @@ WebSendBuffer::AsyncSendNextPacket(boost::shared_ptr<SessionData> session)
 void
 WebSendBuffer::InternalStorePacket(boost::shared_ptr<SessionData> session, boost::shared_ptr<NetPacket> packet)
 {
+	// The connection is already being closed for an earlier send failure or
+	// backlog overflow. Do not add more data to WebSocket++'s queue meanwhile.
+	if (closeAfterSend)
+		return;
+
 	boost::shared_ptr<WebSocketData> webData = session->GetWebData();
 	const bool prefixed = webData && webData->lengthPrefixed;
 
@@ -86,7 +93,8 @@ WebSendBuffer::InternalStorePacket(boost::shared_ptr<SessionData> session, boost
 	if (webData && webData->endpoint) {
 		websocketpp::lib::error_code ec;
 		webData->endpoint->Send(webData->webHandle, string((const char *)buf, packetSize + headerSize), ec);
-		if (ec) {
+		if (ec || webData->endpoint->GetBufferedAmount(webData->webHandle)
+				> MAX_WEBSOCKET_SEND_QUEUE_SIZE) {
 			SetCloseAfterSend();
 		}
 	} else {
@@ -95,4 +103,3 @@ WebSendBuffer::InternalStorePacket(boost::shared_ptr<SessionData> session, boost
 
 	delete[] buf;
 }
-

--- a/src/net/websocketdata.h
+++ b/src/net/websocketdata.h
@@ -52,7 +52,8 @@ public:
 	virtual void Send(websocketpp::connection_hdl hdl, const std::string &payload,
 					  websocketpp::lib::error_code &ec) = 0;
 	virtual void Close(websocketpp::connection_hdl hdl, const std::string &reason,
-					   websocketpp::lib::error_code &ec) = 0;
+					  websocketpp::lib::error_code &ec) = 0;
+	virtual size_t GetBufferedAmount(websocketpp::connection_hdl hdl) = 0;
 	// Remote IP address of the connection, or empty string on failure.
 	virtual std::string RemoteAddress(websocketpp::connection_hdl hdl) = 0;
 };
@@ -73,6 +74,17 @@ public:
 			   websocketpp::lib::error_code &ec) override
 	{
 		m_server->close(hdl, websocketpp::close::status::normal, reason, ec);
+	}
+
+	size_t GetBufferedAmount(websocketpp::connection_hdl hdl) override
+	{
+		try {
+			typename ServerType::connection_ptr con = m_server->get_con_from_hdl(hdl);
+			if (con)
+				return con->get_buffered_amount();
+		} catch (...) {
+		}
+		return 0;
 	}
 
 	std::string RemoteAddress(websocketpp::connection_hdl hdl) override


### PR DESCRIPTION
WebSocket sessions bypass the 1 MiB outbound queue limit applied to TCP sessions. A client that stops reading can retain a growing WebSocket++ send queue while broadcast messages continue, allowing memory exhaustion.

Expose WebSocket++’s buffered-byte count through the endpoint adapter, close a session once it exceeds the same 1 MiB limit, and stop appending packets while closure is pending.