### PR TITLE
Close WebSocket sessions on invalid packets

### DIFF
--- a/src/net/webreceivebuffer.cpp
+++ b/src/net/webreceivebuffer.cpp
@@ -38,6 +38,7 @@ using namespace std;
 
 
 WebReceiveBuffer::WebReceiveBuffer()
+	: m_unparsablePackets(0)
 {
 }
 
@@ -102,6 +103,10 @@ WebReceiveBuffer::ScanPrefixedPackets(boost::shared_ptr<SessionData> session)
 			break; // Wait for the rest of the packet.
 		}
 		ProcessPacket(session, m_recvBuffer.data() + NET_HEADER_SIZE, packetSize);
+		if (session->GetState() == SessionData::Closed) {
+			m_recvBuffer.clear();
+			return;
+		}
 		m_recvBuffer.erase(0, packetSize + NET_HEADER_SIZE);
 	}
 }
@@ -112,15 +117,28 @@ WebReceiveBuffer::ProcessPacket(boost::shared_ptr<SessionData> session, const ch
 	boost::shared_ptr<NetPacket> tmpPacket;
 	try {
 		tmpPacket = NetPacket::Create(data, size);
-		if (!tmpPacket || !validator.IsValidPacket(*tmpPacket)) {
-			LOG_ERROR("Session " << session->GetId() << " - Invalid packet"
-					  << (tmpPacket ? string(": ") + std::to_string(tmpPacket->GetMsg()->messagetype()) : ""));
-			tmpPacket.reset();
+		if (!tmpPacket) {
+			++m_unparsablePackets;
+			LOG_ERROR("Session " << session->GetId() << " - Unparsable WebSocket packet ("
+					  << m_unparsablePackets << "/" << MAX_WEBSOCKET_UNPARSABLE_PACKETS << ").");
+			if (m_unparsablePackets >= MAX_WEBSOCKET_UNPARSABLE_PACKETS) {
+				LOG_ERROR("Session " << session->GetId()
+						  << " - Too many unparsable WebSocket packets - closing connection");
+				session->Close();
+			}
+			return;
+		}
+		if (!validator.IsValidPacket(*tmpPacket)) {
+			LOG_ERROR("Session " << session->GetId() << " - Invalid packet: "
+					  << tmpPacket->GetMsg()->messagetype() << " - closing connection");
+			session->Close();
+			return;
 		}
 	} catch (const exception &e) {
-		LOG_ERROR("Session " << session->GetId() << " - " << e.what());
+		LOG_ERROR("Session " << session->GetId() << " - " << e.what()
+				  << " - closing connection");
+		session->Close();
+		return;
 	}
-	if (tmpPacket) {
-		session->HandlePacket(tmpPacket);
-	}
+	session->HandlePacket(tmpPacket);
 }

--- a/src/net/webreceivebuffer.h
+++ b/src/net/webreceivebuffer.h
@@ -35,6 +35,8 @@
 
 #include <net/receivebuffer.h>
 
+#define MAX_WEBSOCKET_UNPARSABLE_PACKETS 10
+
 class WebReceiveBuffer : public ReceiveBuffer
 {
 public:
@@ -53,6 +55,9 @@ private:
 	// Accumulation buffer, only used in length-prefixed mode (packets may be
 	// split across or coalesced within websocket messages).
 	std::string m_recvBuffer;
+	// Keep the same tolerance for unparseable protobuf payloads as the native
+	// TCP receive path.  A peer which continues to send them is disconnected.
+	unsigned m_unparsablePackets;
 };
 
 #endif


### PR DESCRIPTION
WebSocket packets reach `ServerAcceptWebHelper::on_message` and
`WebReceiveBuffer::ProcessPacket`. Unlike native TCP, parse and validation
failures were logged and discarded while the connection remained open. A
client could repeatedly send malformed binary messages, causing unbounded
parsing and log work.

This closes the session on validation failures and parse exceptions. It keeps
the native transport's tolerance for up to ten unparsable packets, then closes
the connection.