### PR TITLE
Bound spectator lists in lobby snapshots

### DIFF
--- a/src/net/servergamestate.cpp
+++ b/src/net/servergamestate.cpp
@@ -94,6 +94,11 @@ using namespace boost::chrono;
 
 // Helper functions
 
+static bool CanAcceptSpectator(const boost::shared_ptr<ServerGame> &server)
+{
+	return server->GetSpectatorIdList().size() < SERVER_MAX_NUM_SPECTATORS_PER_GAME;
+}
+
 static void SendPlayerAction(ServerGame &server, boost::shared_ptr<PlayerInterface> player)
 {
 	if (!player.get())
@@ -235,6 +240,7 @@ SetPlayerResult(PlayerResult &playerResult, boost::shared_ptr<PlayerInterface> t
 }
 
 //-----------------------------------------------------------------------------
+
 
 ServerGameState::~ServerGameState()
 {
@@ -586,7 +592,7 @@ void
 ServerGameStateInit::HandleNewSpectator(boost::shared_ptr<ServerGame> server, boost::shared_ptr<SessionData> session)
 {
 	if (session && session->GetPlayerData()) {
-		if (server->GetSpectatorIdList().size() >= SERVER_MAX_NUM_SPECTATORS_PER_GAME) {
+		if (!CanAcceptSpectator(server)) {
 			server->MoveSessionToLobby(session, NTF_NET_REMOVED_GAME_FULL);
 		} else {
 			AcceptNewSession(server, session, true);
@@ -813,7 +819,10 @@ void
 ServerGameStateStartGame::HandleNewSpectator(boost::shared_ptr<ServerGame> server, boost::shared_ptr<SessionData> session)
 {
 	if (session && session->GetPlayerData()) {
-		AcceptNewSession(server, session, true);
+		if (!CanAcceptSpectator(server))
+			server->MoveSessionToLobby(session, NTF_NET_REMOVED_GAME_FULL);
+		else
+			AcceptNewSession(server, session, true);
 	}
 }
 
@@ -959,9 +968,13 @@ void
 AbstractServerGameStateRunning::HandleNewSpectator(boost::shared_ptr<ServerGame> server, boost::shared_ptr<SessionData> session)
 {
 	if (session && session->GetPlayerData()) {
-		AcceptNewSession(server, session, true);
-		session->SetState(SessionData::SpectatorWaiting);
-		server->AddNewSpectator(session->GetPlayerData()->GetUniqueId());
+		if (!CanAcceptSpectator(server)) {
+			server->MoveSessionToLobby(session, NTF_NET_REMOVED_GAME_FULL);
+		} else {
+			AcceptNewSession(server, session, true);
+			session->SetState(SessionData::SpectatorWaiting);
+			server->AddNewSpectator(session->GetPlayerData()->GetUniqueId());
+		}
 	}
 }
 
@@ -1809,4 +1822,3 @@ ServerGameStateFinal::Instance()
 }
 
 //-----------------------------------------------------------------------------
-

--- a/src/net/serverlobbythread.cpp
+++ b/src/net/serverlobbythread.cpp
@@ -2530,7 +2530,21 @@ ServerLobbyThread::SendGameList(boost::shared_ptr<SessionData> s)
 	GameMap::const_iterator game_i = m_gameMap.begin();
 	GameMap::const_iterator game_end = m_gameMap.end();
 	while (game_i != game_end) {
-		GetSender().Send(s, CreateNetPacketGameListNew(*game_i->second));
+		const ServerGame &game = *game_i->second;
+		GetSender().Send(s, CreateNetPacketGameListNew(game));
+
+		// A native protocol packet is limited to MAX_PACKET_SIZE. Send existing
+		// spectators individually instead of growing GameListNew past that
+		// limit. This also keeps PlayerInfoRequestMessage batches small.
+		PlayerIdList spectatorIds = game.GetSpectatorIdList();
+		for (PlayerIdList::const_iterator id = spectatorIds.begin(); id != spectatorIds.end(); ++id) {
+			boost::shared_ptr<NetPacket> packet(new NetPacket);
+			packet->GetMsg()->set_messagetype(PokerTHMessage::Type_GameListSpectatorJoinedMessage);
+			GameListSpectatorJoinedMessage *message = packet->GetMsg()->mutable_gamelistspectatorjoinedmessage();
+			message->set_gameid(game.GetId());
+			message->set_playerid(*id);
+			GetSender().Send(s, packet);
+		}
 		++game_i;
 	}
 }
@@ -2707,14 +2721,6 @@ ServerLobbyThread::CreateNetPacketGameListNew(const ServerGame &game)
 	PlayerIdList::const_iterator end = tmpList.end();
 	while (i != end) {
 		netGameList->add_playerids(*i);
-		++i;
-	}
-
-	tmpList = game.GetSpectatorIdList();
-	i = tmpList.begin();
-	end = tmpList.end();
-	while (i != end) {
-		netGameList->add_spectatorids(*i);
 		++i;
 	}
 


### PR DESCRIPTION
Running games accepted unlimited spectators, while the initial game state
limited them. `SendGameList` included every spectator ID in one
`GameListNewMessage`; this can exceed the native 384-byte packet limit and
disconnect clients during lobby synchronization. It also led clients to create
oversized player-info requests.

This applies the spectator limit in every game state. Lobby snapshots now send
the game first and existing spectators as individual notifications, keeping
every protocol message within its intended bounds.