### PR TITLE
Add limits to server list processing

### DIFF
--- a/src/net/clientstate.cpp
+++ b/src/net/clientstate.cpp
@@ -54,7 +54,6 @@
 #include <boost/bind/bind.hpp>
 #include <boost/foreach.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>
-#include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/zlib.hpp>
 #include <boost/filesystem.hpp>
 
@@ -88,6 +87,9 @@ using namespace boost::chrono;
 
 #define CLIENT_WAIT_TIMEOUT_MSEC	50
 #define CLIENT_CONNECT_TIMEOUT_SEC	12
+#define MAX_SERVERLIST_DOWNLOAD_SIZE (1024 * 1024)
+#define MAX_SERVERLIST_XML_SIZE (4 * 1024 * 1024)
+#define MAX_SERVERLIST_SERVERS 256
 
 
 ClientState::~ClientState()
@@ -236,7 +238,8 @@ ClientStateStartServerListDownload::Enter(boost::shared_ptr<ClientThread> client
 	} else {
 		// Download the server list.
 		boost::shared_ptr<DownloadHelper> downloader(new DownloadHelper);
-		downloader->Init(client->GetContext().GetServerListUrl(), tmpServerListPath.string());
+		downloader->Init(client->GetContext().GetServerListUrl(), tmpServerListPath.string(),
+				"", "", MAX_SERVERLIST_DOWNLOAD_SIZE);
 		ClientStateDownloadingServerList::Instance().SetDownloadHelper(downloader);
 		client->SetState(ClientStateDownloadingServerList::Instance());
 	}
@@ -325,6 +328,9 @@ ClientStateReadingServerList::Enter(boost::shared_ptr<ClientThread> client)
 	ClientContext &context = client->GetContext();
 	path zippedServerListPath(context.GetCacheDir());
 	zippedServerListPath /= context.GetServerListUrl().substr(context.GetServerListUrl().find_last_of('/') + 1);
+	if (file_size(zippedServerListPath) > MAX_SERVERLIST_DOWNLOAD_SIZE)
+		throw ClientException(__FILE__, __LINE__, ERR_SOCK_INVALID_SERVERLIST_XML, 0);
+
 	path xmlServerListPath;
 	if (zippedServerListPath.extension().string() == ".z") {
 		xmlServerListPath = zippedServerListPath;
@@ -337,7 +343,20 @@ ClientStateReadingServerList::Enter(boost::shared_ptr<ClientThread> client)
 			boost::iostreams::filtering_streambuf<boost::iostreams::input> in;
 			in.push(boost::iostreams::zlib_decompressor());
 			in.push(inFile);
-			boost::iostreams::copy(in, outFile);
+			std::istream inputStream(&in);
+			char buffer[8192];
+			size_t xmlSize = 0;
+			while (inputStream.read(buffer, sizeof(buffer)) || inputStream.gcount() != 0) {
+				const size_t bytesRead = static_cast<size_t>(inputStream.gcount());
+				if (bytesRead > MAX_SERVERLIST_XML_SIZE - xmlSize)
+					throw ClientException(__FILE__, __LINE__, ERR_SOCK_UNZIP_FAILED, 0);
+				outFile.write(buffer, bytesRead);
+				if (!outFile)
+					throw ClientException(__FILE__, __LINE__, ERR_SOCK_UNZIP_FAILED, 0);
+				xmlSize += bytesRead;
+			}
+			if (!inputStream.eof())
+				throw ClientException(__FILE__, __LINE__, ERR_SOCK_UNZIP_FAILED, 0);
 		} catch (...) {
 			throw ClientException(__FILE__, __LINE__, ERR_SOCK_UNZIP_FAILED, 0);
 		}
@@ -357,6 +376,9 @@ ClientStateReadingServerList::Enter(boost::shared_ptr<ClientThread> client)
 		QDomElement nextServer = xmlDoc.documentElement().firstChildElement("Server");
 
 		while (!nextServer.isNull()) {
+			if (serverCount == MAX_SERVERLIST_SERVERS)
+				throw ClientException(__FILE__, __LINE__, ERR_SOCK_INVALID_SERVERLIST_XML, 0);
+
 			ServerInfo serverInfo;
 			{
 				int tmpId = nextServer.attribute("id").toInt();
@@ -2865,4 +2887,3 @@ ClientStateFinal::Instance()
     static ClientStateFinal state;
     return state;
 }
-

--- a/src/net/downloadhelper.cpp
+++ b/src/net/downloadhelper.cpp
@@ -53,6 +53,24 @@ using namespace std;
 namespace
 {
 
+bool
+WriteReplyData(TransferData *transferData, size_t maxFileSize)
+{
+	QByteArray data = transferData->networkReply->readAll();
+	if (data.isEmpty() || !transferData->targetFile)
+		return true;
+
+	const size_t receivedSize = static_cast<size_t>(data.size());
+	const size_t currentSize = static_cast<size_t>(transferData->targetFile->size());
+	if (maxFileSize != 0
+			&& (currentSize > maxFileSize || receivedSize > maxFileSize - currentSize)) {
+		LOG_ERROR("Download exceeds configured size limit.");
+		return false;
+	}
+
+	return transferData->targetFile->write(data) == data.size();
+}
+
 // Root certificates for verifying the download on Android.
 //
 // Android keeps its trust store as individual files named after a hash of the
@@ -122,7 +140,7 @@ DownloadHelper::~DownloadHelper()
 }
 
 void
-DownloadHelper::InternalInit(const string &/*url*/, const string &targetFileName, const string &/*user*/, const string &/*password*/, size_t /*filesize*/, const string &/*httpPost*/)
+DownloadHelper::InternalInit(const string &/*url*/, const string &targetFileName, const string &/*user*/, const string &/*password*/, size_t filesize, const string &/*httpPost*/)
 {
 	// Open target file for writing.
 	const QString targetPath = QString::fromStdString(targetFileName);
@@ -161,13 +179,22 @@ DownloadHelper::InternalInit(const string &/*url*/, const string &targetFileName
 #endif
 
 	GetData()->networkReply = GetData()->networkManager->get(request);
+	if (filesize != 0)
+		GetData()->networkReply->setReadBufferSize(static_cast<qint64>(filesize));
+
+	QObject::connect(GetData()->networkReply, &QNetworkReply::metaDataChanged, [this, filesize]() {
+		const QVariant contentLength = GetData()->networkReply->header(QNetworkRequest::ContentLengthHeader);
+		if (filesize != 0 && contentLength.isValid()
+				&& contentLength.toULongLong() > filesize) {
+			LOG_ERROR("Download exceeds configured size limit.");
+			GetData()->networkReply->abort();
+		}
+	});
 
 	// Connect signals to write data as it arrives
-	QObject::connect(GetData()->networkReply, &QNetworkReply::readyRead, [this]() {
-		QByteArray data = GetData()->networkReply->readAll();
-		if (GetData()->targetFile) {
-			GetData()->targetFile->write(data);
-		}
+	QObject::connect(GetData()->networkReply, &QNetworkReply::readyRead, [this, filesize]() {
+		if (!WriteReplyData(GetData().get(), filesize))
+			GetData()->networkReply->abort();
 	});
 
 	// Certificate errors are never ignored: doing so would let anyone on the
@@ -180,18 +207,16 @@ DownloadHelper::InternalInit(const string &/*url*/, const string &targetFileName
 				LOG_ERROR("TLS: rejecting download - " << error.errorString().toStdString());
 		});
 
-	QObject::connect(GetData()->networkReply, &QNetworkReply::finished, [this]() {
+	QObject::connect(GetData()->networkReply, &QNetworkReply::finished, [this, filesize]() {
 		if (GetData()->networkReply->error() == QNetworkReply::NoError) {
 			// Write any remaining data
-			QByteArray data = GetData()->networkReply->readAll();
-			if (GetData()->targetFile && !data.isEmpty()) {
-				GetData()->targetFile->write(data);
-			}
-			GetData()->errorCode = 0;
+			if (WriteReplyData(GetData().get(), filesize))
+				GetData()->errorCode = 0;
+			else
+				GetData()->errorCode = QNetworkReply::UnknownNetworkError;
 		} else {
 			GetData()->errorCode = GetData()->networkReply->error();
 		}
 		GetData()->finished = true;
 	});
 }
-


### PR DESCRIPTION
The server-list path wrote every response to cache, expanded .z files
without an output bound, and parsed every Server element. This made
malformed or unexpectedly large cache data needlessly expensive to process.

This hardens the path with 1 MB download, 4 MB decompressed XML, and
256-server limits. The transfer helper aborts a known oversized reply and
stops writing once the cap is reached.