### PR TITLE
Verify HTTPS upload peers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ set(POKERTH_LIB_SRC
     src/net/sessionmanager.cpp
     src/net/socket_startup.cpp
     src/net/tlspinning.cpp
+    src/net/tlstrust.cpp
     src/net/clientexception.cpp 
     src/net/netcontext.cpp 
     src/net/netexception.cpp 
@@ -348,4 +349,3 @@ target_link_libraries(pokerth_globalnotice
     Qt6::Xml
 )
 target_include_directories(pokerth_globalnotice PRIVATE ${CMAKE_SOURCE_DIR}/src)
-

--- a/src/net/downloadhelper.cpp
+++ b/src/net/downloadhelper.cpp
@@ -34,6 +34,7 @@
 #include <net/netexception.h>
 #include <net/socket_msg.h>
 #include <net/transferdata.h>
+#include <net/tlstrust.h>
 
 #include <core/loghelper.h>
 
@@ -42,9 +43,6 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDir>
-#include <QSslCertificate>
-#include <QSslConfiguration>
-#include <QSslSocket>
 
 #include <cstdio>
 
@@ -69,63 +67,6 @@ WriteReplyData(TransferData *transferData, size_t maxFileSize)
 	}
 
 	return transferData->targetFile->write(data) == data.size();
-}
-
-// Root certificates for verifying the download on Android.
-//
-// Android keeps its trust store as individual files named after a hash of the
-// subject, which the OpenSSL build behind Qt does not discover on its own. That
-// gap used to be papered over by accepting every certificate error, which left
-// the server list download unauthenticated (issue #516).
-//
-// The device store is preferred because the system keeps it current, so a root
-// withdrawn or added after this release still takes effect. Only if it cannot be
-// read does the bundle shipped with the app apply. Returning an empty list makes
-// the caller fail the download instead of falling back to no verification.
-//
-// Note that these are the system roots only. Certificates a user installed by
-// hand live elsewhere and stay untrusted, which is what Android does for apps
-// since version 7 anyway - a device with an added interception CA cannot read
-// this traffic.
-//
-// Compiled on every platform (not just Android) so that the desktop build keeps
-// this code honest; it is only ever called there.
-QList<QSslCertificate>
-LoadSystemCaCertificates()
-{
-	// Android 14 moved the store into the conscrypt APEX, older releases keep
-	// it below /system. The entries are PEM with a trailing text dump.
-	static const char *const systemStores[] = {
-		"/apex/com.android.conscrypt/cacerts",
-		"/system/etc/security/cacerts"
-	};
-
-	for (const char *const store : systemStores) {
-		const QString pattern = QString::fromLatin1(store) + QLatin1String("/*");
-		QList<QSslCertificate> certs = QSslCertificate::fromPath(
-										   pattern, QSsl::Pem, QSslCertificate::PatternSyntax::Wildcard);
-		if (certs.isEmpty()) {
-			certs = QSslCertificate::fromPath(
-						pattern, QSsl::Der, QSslCertificate::PatternSyntax::Wildcard);
-		}
-		if (!certs.isEmpty()) {
-			LOG_MSG("TLS: using " << certs.size() << " root certificates from " << store << ".");
-			return certs;
-		}
-	}
-
-	// Shipped fallback, bundled into the Android resource next to the other
-	// data/ files (see the android data bundle in the QML client CMakeLists).
-	QList<QSslCertificate> bundled = QSslCertificate::fromPath(
-										 QLatin1String(":/android/android-data/misc/cacert.pem"), QSsl::Pem);
-	if (!bundled.isEmpty()) {
-		LOG_MSG("TLS: system trust store unreadable, using " << bundled.size()
-				<< " bundled root certificates.");
-		return bundled;
-	}
-
-	LOG_ERROR("TLS: no root certificates available - the download cannot be verified and will fail.");
-	return QList<QSslCertificate>();
 }
 
 }
@@ -167,16 +108,7 @@ DownloadHelper::InternalInit(const string &/*url*/, const string &targetFileName
 	QNetworkRequest request(qUrl);
 	request.setRawHeader("User-Agent", "PokerTH/2.0 (Qt Network)");
 
-#ifdef ANDROID
-	// Verify the peer against the device trust store (see LoadSystemCaCertificates).
-	// Everywhere else Qt already verifies with the platform defaults.
-	{
-		QSslConfiguration sslConfig = request.sslConfiguration();
-		sslConfig.setPeerVerifyMode(QSslSocket::VerifyPeer);
-		sslConfig.setCaCertificates(LoadSystemCaCertificates());
-		request.setSslConfiguration(sslConfig);
-	}
-#endif
+	TlsTrust::ConfigureRequest(request);
 
 	GetData()->networkReply = GetData()->networkManager->get(request);
 	if (filesize != 0)

--- a/src/net/tlstrust.cpp
+++ b/src/net/tlstrust.cpp
@@ -1,0 +1,73 @@
+/*****************************************************************************
+ * PokerTH - The open source texas holdem engine                             *
+ * Copyright (C) 2006-2012 Felix Hammer, Florian Thauer, Lothar May          *
+ *                                                                           *
+ * This program is free software: you can redistribute it and/or modify      *
+ * it under the terms of the GNU Affero General Public License as            *
+ * published by the Free Software Foundation, either version 3 of the        *
+ * License, or (at your option) any later version.                           *
+ *****************************************************************************/
+
+#include <net/tlstrust.h>
+
+#include <core/loghelper.h>
+
+#include <QSslConfiguration>
+#include <QSslSocket>
+
+#ifdef ANDROID
+#include <QDir>
+#include <QSslCertificate>
+#endif
+
+namespace
+{
+
+#ifdef ANDROID
+QList<QSslCertificate>
+LoadSystemCaCertificates()
+{
+	static const char *const systemStores[] = {
+		"/apex/com.android.conscrypt/cacerts",
+		"/system/etc/security/cacerts"
+	};
+
+	for (const char *const store : systemStores) {
+		const QString pattern = QString::fromLatin1(store) + QLatin1String("/*");
+		QList<QSslCertificate> certs = QSslCertificate::fromPath(
+				pattern, QSsl::Pem, QSslCertificate::PatternSyntax::Wildcard);
+		if (certs.isEmpty()) {
+			certs = QSslCertificate::fromPath(
+				pattern, QSsl::Der, QSslCertificate::PatternSyntax::Wildcard);
+		}
+		if (!certs.isEmpty()) {
+			LOG_MSG("TLS: using " << certs.size() << " root certificates from " << store << ".");
+			return certs;
+		}
+	}
+
+	QList<QSslCertificate> bundled = QSslCertificate::fromPath(
+			QLatin1String(":/android/android-data/misc/cacert.pem"), QSsl::Pem);
+	if (!bundled.isEmpty()) {
+		LOG_MSG("TLS: system trust store unreadable, using " << bundled.size()
+				<< " bundled root certificates.");
+		return bundled;
+	}
+
+	LOG_ERROR("TLS: no root certificates available - the request cannot be verified and will fail.");
+	return QList<QSslCertificate>();
+}
+#endif
+
+}
+
+void
+TlsTrust::ConfigureRequest(QNetworkRequest &request)
+{
+	QSslConfiguration sslConfig = request.sslConfiguration();
+	sslConfig.setPeerVerifyMode(QSslSocket::VerifyPeer);
+#ifdef ANDROID
+	sslConfig.setCaCertificates(LoadSystemCaCertificates());
+#endif
+	request.setSslConfiguration(sslConfig);
+}

--- a/src/net/tlstrust.h
+++ b/src/net/tlstrust.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ * PokerTH - The open source texas holdem engine                             *
+ * Copyright (C) 2006-2012 Felix Hammer, Florian Thauer, Lothar May          *
+ *                                                                           *
+ * This program is free software: you can redistribute it and/or modify      *
+ * it under the terms of the GNU Affero General Public License as            *
+ * published by the Free Software Foundation, either version 3 of the        *
+ * License, or (at your option) any later version.                           *
+ *****************************************************************************/
+/* TLS trust setup for Qt network requests. */
+
+#ifndef _TLSTRUST_H_
+#define _TLSTRUST_H_
+
+#include <QNetworkRequest>
+
+namespace TlsTrust
+{
+
+// Configure platform trust roots for a request. Desktop Qt uses the platform
+// defaults; Android needs an explicit root list.
+void ConfigureRequest(QNetworkRequest &request);
+
+}
+
+#endif

--- a/src/net/uploadhelper.cpp
+++ b/src/net/uploadhelper.cpp
@@ -34,6 +34,7 @@
 #include <net/netexception.h>
 #include <net/socket_msg.h>
 #include <net/transferdata.h>
+#include <net/tlstrust.h>
 #include <sys/stat.h>
 
 #include <QUrl>
@@ -41,7 +42,6 @@
 #include <QHttpMultiPart>
 #include <QFile>
 #include <QFileInfo>
-#include <QSslSocket>
 
 #include <cstdio>
 
@@ -68,10 +68,7 @@ UploadHelper::InternalInit(const string &/*url*/, const string &targetFileName, 
 	QNetworkRequest request(qUrl);
 	request.setRawHeader("User-Agent", "PokerTH/2.0 (Qt Network)");
 
-	// Disable SSL certificate verification (matching old curl behavior)
-	QSslConfiguration sslConfig = request.sslConfiguration();
-	sslConfig.setPeerVerifyMode(QSslSocket::VerifyNone);
-	request.setSslConfiguration(sslConfig);
+	TlsTrust::ConfigureRequest(request);
 
 	// Set authentication if provided
 	if (!user.empty() || !password.empty()) {
@@ -126,4 +123,3 @@ UploadHelper::InternalInit(const string &/*url*/, const string &targetFileName, 
 		GetData()->finished = true;
 	});
 }
-


### PR DESCRIPTION
UploadHelper configured every HTTPS request with VerifyNone. This affects user
log uploads and external avatar-store uploads; a network attacker could present
a forged certificate, inspect or alter data, and capture Basic credentials
where configured.

This restores peer verification for uploads. The Android trust-root setup used
by downloads is now shared, so uploads use the same system roots and bundled
fallback.