### PR TITLE
server: reject rejoin requests for unstarted games

### DIFF
--- a/src/net/serverlobbythread.cpp
+++ b/src/net/serverlobbythread.cpp
@@ -1607,7 +1607,11 @@ ServerLobbyThread::HandleNetPacketRejoinGame(boost::shared_ptr<SessionData> sess
 
 	if (pos != m_gameMap.end()) {
 		boost::shared_ptr<ServerGame> game = pos->second;
-		MoveSessionToGame(game, session, rejoinGame.autoleave(), false);
+		if (game->IsRunning()) {
+			MoveSessionToGame(game, session, rejoinGame.autoleave(), false);
+		} else {
+			SendJoinGameFailed(session, rejoinGame.gameid(), NTF_NET_JOIN_REJOIN_FAILED);
+		}
 	} else {
 		SendJoinGameFailed(session, rejoinGame.gameid(), NTF_NET_JOIN_GAME_INVALID);
 	}


### PR DESCRIPTION
The lobby accepted RejoinExistingGameMessage for any game ID in m_gameMap. Before a game started, this moved the session directly into the game and bypassed the normal join checks for passwords, invitations, guest restrictions, ranking limits, and duplicate IPs.

Reject rejoin requests unless the target game is running. Legitimate reconnects still use the existing running-game GUID and kicked-player validation.

The dedicated server target builds successfully with this change.