### PR TITLE
server: rate limit broadcast chat per connection

### DIFF
--- a/src/net/servergamestate.cpp
+++ b/src/net/servergamestate.cpp
@@ -283,14 +283,13 @@ AbstractServerGameStateReceiving::ProcessPacket(boost::shared_ptr<ServerGame> se
 		const VoteKickRequestMessage &netVoteKick = packet->GetMsg()->votekickrequestmessage();
 		server->InternalVoteKick(session, netVoteKick.petitionid(), netVoteKick.votekick() ? KICK_VOTE_IN_FAVOUR : KICK_VOTE_AGAINST);
 	}
-	// Chat text is always allowed.
+	// Handle chat text.
 	else if (packet->GetMsg()->messagetype() == PokerTHMessage::Type_ChatRequestMessage) {
 		bool chatSent = false;
 		const ChatRequestMessage &netChatRequest = packet->GetMsg()->chatrequestmessage();
 		// Only forward if this player is known and not a guest.
 		if (session->GetPlayerData()->GetRights() != PLAYER_RIGHTS_GUEST) {
-			// Forward chat text to all players.
-			// TODO: Some limitation needed.
+			// Forward chat text to all players at a limited rate.
 			if (!netChatRequest.has_targetgameid()) {
 				if (!server->IsRunning()) {
 					server->GetLobbyThread().HandleChatRequest(session, netChatRequest);
@@ -300,7 +299,7 @@ AbstractServerGameStateReceiving::ProcessPacket(boost::shared_ptr<ServerGame> se
 				boost::shared_ptr<PlayerInterface> tmpPlayer (server->GetPlayerInterfaceFromGame(session->GetPlayerData()->GetUniqueId()));
 				// If we did not find the player, then the game did not start yet. Allow chat for now.
 				// Otherwise, check whether the player is muted.
-				if (!tmpPlayer || !tmpPlayer->isMuted()) {
+				if ((!tmpPlayer || !tmpPlayer->isMuted()) && session->AcquireChatToken()) {
 					boost::shared_ptr<NetPacket> packet(new NetPacket);
 					packet->GetMsg()->set_messagetype(PokerTHMessage::Type_ChatMessage);
 					ChatMessage *netChat = packet->GetMsg()->mutable_chatmessage();

--- a/src/net/serverlobbythread.cpp
+++ b/src/net/serverlobbythread.cpp
@@ -1624,6 +1624,15 @@ ServerLobbyThread::HandleNetPacketChatRequest(boost::shared_ptr<SessionData> ses
 	// Guests are not allowed to chat.
 	if (session->GetPlayerData() && session->GetPlayerData()->GetRights() != PLAYER_RIGHTS_GUEST) {
 		if (!chatRequest.has_targetgameid() && !chatRequest.has_targetplayerid()) {
+			if (!session->AcquireChatToken()) {
+				boost::shared_ptr<NetPacket> packet(new NetPacket);
+				packet->GetMsg()->set_messagetype(PokerTHMessage::Type_ChatRejectMessage);
+				ChatRejectMessage *netReject = packet->GetMsg()->mutable_chatrejectmessage();
+				netReject->set_chattext(chatRequest.chattext());
+				GetSender().Send(session, packet);
+				return;
+			}
+
 			string chatMsg(chatRequest.chattext());
 
 			boost::shared_ptr<NetPacket> packet(new NetPacket);

--- a/src/net/sessiondata.cpp
+++ b/src/net/sessiondata.cpp
@@ -50,6 +50,7 @@ using namespace boost::chrono;
 
 SessionData::SessionData(boost::shared_ptr<boost::asio::ip::tcp::socket> sock, SessionId id, SessionDataCallback &cb, boost::asio::io_context &ioService)
 	: m_socket(sock), m_id(id), m_state(SessionData::Init), m_readyFlag(false), m_wantsLobbyMsg(true),
+	  m_chatWindowStart(std::chrono::steady_clock::now()), m_chatMessagesInWindow(0),
 	  m_activityTimeoutSec(0), m_activityWarningRemainingSec(0), m_globalTimeoutSec(0), m_initTimeoutTimer(ioService), m_globalTimeoutTimer(ioService),
 	  m_activityTimeoutTimer(ioService), m_callback(cb), m_authSession(NULL), m_curAuthStep(0)
 {
@@ -59,6 +60,7 @@ SessionData::SessionData(boost::shared_ptr<boost::asio::ip::tcp::socket> sock, S
 
 SessionData::SessionData(boost::shared_ptr<WebSocketData> webData, SessionId id, SessionDataCallback &cb, boost::asio::io_context &ioService, int /*filler*/)
 	: m_webData(webData), m_id(id), m_state(SessionData::Init), m_readyFlag(false), m_wantsLobbyMsg(true),
+	  m_chatWindowStart(std::chrono::steady_clock::now()), m_chatMessagesInWindow(0),
 	  m_activityTimeoutSec(0), m_activityWarningRemainingSec(0), m_globalTimeoutSec(0), m_initTimeoutTimer(ioService), m_globalTimeoutTimer(ioService),
 	  m_activityTimeoutTimer(ioService), m_callback(cb), m_authSession(NULL), m_curAuthStep(0)
 {
@@ -69,6 +71,7 @@ SessionData::SessionData(boost::shared_ptr<WebSocketData> webData, SessionId id,
 SessionData::SessionData(boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> sslStream, SessionId id, SessionDataCallback &cb, boost::asio::io_context &ioService, int /*filler*/)
     : m_socket(), m_webData(), m_id(id), m_game(), m_state(SessionData::Init), m_clientAddr(),
       m_receiveBuffer(), m_sendBuffer(), m_readyFlag(false), m_wantsLobbyMsg(true),
+      m_chatWindowStart(std::chrono::steady_clock::now()), m_chatMessagesInWindow(0),
       m_activityTimeoutSec(0), m_activityWarningRemainingSec(0), m_globalTimeoutSec(0),
       m_initTimeoutTimer(ioService), m_globalTimeoutTimer(ioService), m_activityTimeoutTimer(ioService),
       m_callback(cb), m_authSession(NULL), m_curAuthStep(0)
@@ -394,6 +397,25 @@ SessionData::ResetGlobalTimeout()
 	}
 }
 
+bool
+SessionData::AcquireChatToken()
+{
+	static const unsigned CHAT_MESSAGES_PER_SECOND = 5;
+	boost::mutex::scoped_lock lock(m_dataMutex);
+
+	const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+	if (now - m_chatWindowStart >= std::chrono::seconds(1)) {
+		m_chatWindowStart = now;
+		m_chatMessagesInWindow = 0;
+	}
+
+	if (m_chatMessagesInWindow >= CHAT_MESSAGES_PER_SECOND)
+		return false;
+
+	++m_chatMessagesInWindow;
+	return true;
+}
+
 void
 SessionData::StartTimerActivityTimeout(unsigned timeoutSec, unsigned warningRemainingSec)
 {
@@ -466,4 +488,3 @@ SessionData::GetRemoteIPAddressFromSocket() const
 
     return std::string();
 }
-

--- a/src/net/sessiondata.h
+++ b/src/net/sessiondata.h
@@ -39,6 +39,7 @@ typedef unsigned SessionId;
 #include <boost/asio/steady_timer.hpp>
 #include <boost/thread.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <chrono>
 #include <string>
 #include <vector>
 #include <boost/asio/ssl.hpp>
@@ -121,6 +122,9 @@ public:
 
 	void ResetActivityTimer();
 	void ResetGlobalTimeout();
+	// Limit broadcast chat independently for each connection. This prevents a
+	// client from turning the server's fan-out into an outgoing flood.
+	bool AcquireChatToken();
 
 	void StartTimerInitTimeout(unsigned timeoutSec);
 	void StartTimerGlobalTimeout(unsigned timeoutSec);
@@ -164,6 +168,8 @@ private:
 	boost::shared_ptr<SendBuffer>	m_sendBuffer;
 	bool							m_readyFlag;
 	bool							m_wantsLobbyMsg;
+	std::chrono::steady_clock::time_point	m_chatWindowStart;
+	unsigned						m_chatMessagesInWindow;
 	unsigned						m_activityTimeoutSec;
 	unsigned						m_activityWarningRemainingSec;
 	unsigned						m_globalTimeoutSec;


### PR DESCRIPTION
A connected client can send ChatRequestMessage packets faster than a user can type. Each accepted broadcast is sent to every lobby, game, and spectator session, allowing one client to fill recipient send queues or consume server egress.

This adds a per-connection limit of five public chat messages per second. Rate-limited messages receive ChatRejectMessage. Private messages are unchanged.