### PR TITLE
permit build with LibreSSL

### DIFF
--- a/src/net/tlspinning.cpp
+++ b/src/net/tlspinning.cpp
@@ -123,12 +123,22 @@ TlsPinning::ComputeSpkiPin(X509 *cert)
 	if (!cert)
 		return pin;
 
+#ifdef LIBRESSL_VERSION_NUMBER
+	X509_PUBKEY *pubKey = X509_get_X509_PUBKEY(cert);
+	if (!pubKey)
+		return pin;
+
+	unsigned char *der = NULL;
+	int derSize = i2d_X509_PUBKEY(pubKey, &der);
+#else
 	const X509_PUBKEY *pubKey = X509_get_X509_PUBKEY(cert);
 	if (!pubKey)
 		return pin;
 
 	unsigned char *der = NULL;
 	const int derSize = i2d_X509_PUBKEY(pubKey, &der);
+#endif
+
 	if (der) {
 		if (derSize > 0) {
 			unsigned char digest[SHA256_DIGEST_LENGTH];


### PR DESCRIPTION
Tested with OpenBSD-current and OpenBSD release 7.9.  Fix for: 
`/usr/ports/pobj/pokerth-2.1.8/pokerth-2.1.8/src/net/tlspinning.cpp:131:22: error: no matching function for call to 'i2d_X509_PUBKEY'
  131 |         const int derSize = i2d_X509_PUBKEY(pubKey, &der);
        |                             ^~~~~~~~~~~~~~~
        /usr/include/openssl/x509.h:493:5: note: candidate function not viable: 1st argument ('const X509_PUBKEY *' (aka 'const struct X509_pubkey_st *')) would lose const qualifier
          493 | int i2d_X509_PUBKEY(X509_PUBKEY *a, unsigned char **out);
                |     ^               ~~~~~~~~~~~~~~
                1 error generated.
                ninja: build stopped: subcommand failed.
`