### PR TITLE
Rate limit private chat messages

### DIFF
--- a/src/net/serverlobbythread.cpp
+++ b/src/net/serverlobbythread.cpp
@@ -1742,18 +1742,17 @@ ServerLobbyThread::HandleNetPacketChatRequest(boost::shared_ptr<SessionData> ses
 						LOG_ERROR("Global Notice: " << chatRequest.chattext().substr(3) << " von " << senderName);
 						SendGlobalChat(chatRequest.chattext().substr(3));
 						chatSent = true;
-					} else {
+					} else if (session->AcquireChatToken()) {
+						boost::shared_ptr<NetPacket> packet(new NetPacket);
+						packet->GetMsg()->set_messagetype(PokerTHMessage::Type_ChatMessage);
+						ChatMessage *netChat = packet->GetMsg()->mutable_chatmessage();
+						netChat->set_chattype(ChatMessage::chatTypePrivate);
+						netChat->set_playerid(session->GetPlayerData()->GetUniqueId());
+						netChat->set_chattext(chatRequest.chattext());
 
-					boost::shared_ptr<NetPacket> packet(new NetPacket);
-					packet->GetMsg()->set_messagetype(PokerTHMessage::Type_ChatMessage);
-					ChatMessage *netChat = packet->GetMsg()->mutable_chatmessage();
-					netChat->set_chattype(ChatMessage::chatTypePrivate);
-					netChat->set_playerid(session->GetPlayerData()->GetUniqueId());
-					netChat->set_chattext(chatRequest.chattext());
-
-					GetSender().Send(targetSession, packet);
-					chatSent = true;
-				}
+						GetSender().Send(targetSession, packet);
+						chatSent = true;
+					}
 			      }
 			}
 		}


### PR DESCRIPTION
Private chat messages bypass the per-session chat rate limiter applied to broadcast messages. An authenticated client can therefore send private messages at protocol speed to a lobby player. If the recipient is slow to read, the recipient's 1 MiB send queue fills and the server closes that connection.

Apply the existing per-session chat limiter before forwarding ordinary private messages. Administrative global notices sent through the legacy `bbcbot` path remain unchanged.