### PR TITLE
Require authentication before establishing sessions

### DIFF
--- a/src/net/serverlobbythread.cpp
+++ b/src/net/serverlobbythread.cpp
@@ -1134,7 +1134,7 @@ ServerLobbyThread::DispatchPacket(boost::shared_ptr<SessionData> session, boost:
 void
 ServerLobbyThread::HandlePacket(boost::shared_ptr<SessionData> session, boost::shared_ptr<NetPacket> packet)
 {
-	if (session && packet) {
+	if (session && packet && session->GetState() != SessionData::Closed) {
 		if (packet->IsClientActivity()) {
 			session->ResetActivityTimer();
 			session->ResetGlobalTimeout();
@@ -1405,6 +1405,10 @@ void
 ServerLobbyThread::HandleNetPacketAvatarHeader(boost::shared_ptr<SessionData> session, const AvatarHeaderMessage &avatarHeader)
 {
 	if (session->GetPlayerData()) {
+		if (session->IsAuthenticationPending()) {
+			SessionError(session, ERR_SOCK_INVALID_STATE);
+			return;
+		}
 		if (avatarHeader.avatarsize() >= MIN_AVATAR_FILE_SIZE && avatarHeader.avatarsize() <= MAX_AVATAR_FILE_SIZE) {
 			boost::shared_ptr<AvatarFile> tmpAvatarFile(new AvatarFile);
 			tmpAvatarFile->fileData.reserve(avatarHeader.avatarsize());
@@ -1425,6 +1429,10 @@ void
 ServerLobbyThread::HandleNetPacketUnknownAvatar(boost::shared_ptr<SessionData> session, const UnknownAvatarMessage &/*unknownAvatar*/)
 {
 	if (session->GetPlayerData()) {
+		if (session->IsAuthenticationPending()) {
+			SessionError(session, ERR_SOCK_INVALID_STATE);
+			return;
+		}
 		// Free memory (just in case).
 		session->GetPlayerData()->SetNetAvatarFile(boost::shared_ptr<AvatarFile>());
 		session->GetPlayerData()->SetAvatarMD5(MD5Buf());
@@ -1449,6 +1457,10 @@ void
 ServerLobbyThread::HandleNetPacketAvatarEnd(boost::shared_ptr<SessionData> session, const AvatarEndMessage &/*avatarEnd*/)
 {
 	if (session->GetPlayerData()) {
+		if (session->IsAuthenticationPending()) {
+			SessionError(session, ERR_SOCK_INVALID_STATE);
+			return;
+		}
 		boost::shared_ptr<AvatarFile> tmpAvatar = session->GetPlayerData()->GetNetAvatarFile();
 		MD5Buf avatarMD5 = session->GetPlayerData()->GetAvatarMD5();
 		if (!avatarMD5.IsZero() && tmpAvatar.get()) {
@@ -2094,6 +2106,7 @@ void
 ServerLobbyThread::AuthenticatePlayer(boost::shared_ptr<SessionData> session)
 {
 	if(session->GetPlayerData()) {
+		session->SetAuthenticationPending(true);
 		m_database->AsyncPlayerLogin(session->GetPlayerData()->GetUniqueId(), session->GetPlayerData()->GetName());
 	}
 }
@@ -2109,6 +2122,7 @@ ServerLobbyThread::UserValid(unsigned playerId, const DBPlayerData &dbPlayerData
 
     std::string providedPassword = tmpSession->AuthGetPassword();
     if (!providedPassword.empty() && providedPassword == dbPlayerData.secret) {
+        tmpSession->SetAuthenticationPending(false);
         tmpSession->GetPlayerData()->SetDBId(dbPlayerData.id);
         tmpSession->GetPlayerData()->SetCountry(dbPlayerData.country);
         // Set admin rights if the player is in the admin list.

--- a/src/net/sessiondata.cpp
+++ b/src/net/sessiondata.cpp
@@ -199,6 +199,20 @@ SessionData::AuthGetPassword() const
     return m_password;
 }
 
+void
+SessionData::SetAuthenticationPending(bool pending)
+{
+	boost::mutex::scoped_lock lock(m_dataMutex);
+	m_authenticationPending = pending;
+}
+
+bool
+SessionData::IsAuthenticationPending() const
+{
+	boost::mutex::scoped_lock lock(m_dataMutex);
+	return m_authenticationPending;
+}
+
 string
 SessionData::AuthGetNextOutMsg() const
 {

--- a/src/net/sessiondata.h
+++ b/src/net/sessiondata.h
@@ -87,6 +87,8 @@ public:
 	std::string AuthGetUser() const;
 	void AuthSetPassword(const std::string &password);
 	std::string AuthGetPassword() const;
+	void SetAuthenticationPending(bool pending);
+	bool IsAuthenticationPending() const;
 	std::string AuthGetNextOutMsg() const;
 	int AuthGetCurStepNum() const;
 
@@ -191,6 +193,7 @@ private:
 	int								m_curAuthStep;
 	std::string						m_nextGsaslMsg;
 	std::string						m_password;
+	bool						m_authenticationPending{false};
 	boost::shared_ptr<PlayerData>	m_playerData;
 	unsigned						m_clientBuildId{0};
 	std::string						m_closeReason;


### PR DESCRIPTION
An authenticated login can currently be established through an avatar response before the asynchronous password check completes. A client can send `UnknownAvatarMessage` immediately after `InitMessage` and be accepted under an unverified nickname.\n\nTrack authentication-pending sessions and reject avatar packets until the database accepts the password. Also ignore packets queued after a session has been closed. Legitimate avatar responses and unauthenticated logins remain unchanged.