### PR TITLE
Render untrusted QML text as plain text

### DIFF
--- a/src/gui/qt6-qml/components/AppLabel.qml
+++ b/src/gui/qt6-qml/components/AppLabel.qml
@@ -6,5 +6,8 @@ import "../config" as Config
 // AppText für Stellen, die bewusst ein Control-Label nutzen. Alle übrigen
 // Eigenschaften setzt der Aufrufer wie bei einem gewöhnlichen Label.
 Label {
+    // User-controlled names and messages are plain text by default. Callers
+    // that intentionally render trusted markup can opt in explicitly.
+    textFormat: Text.PlainText
     font.family: Config.StaticData.loadedFont.font.family
 }

--- a/src/gui/qt6-qml/components/AppText.qml
+++ b/src/gui/qt6-qml/components/AppText.qml
@@ -7,5 +7,8 @@ import "../config" as Config
 // Eigenschaften (color, font.pixelSize, font.bold, …) setzt der Aufrufer wie
 // bei einem gewöhnlichen Text.
 Text {
+    // User-controlled names and messages are plain text by default. Callers
+    // that intentionally render trusted markup can opt in explicitly.
+    textFormat: Text.PlainText
     font.family: Config.StaticData.loadedFont.font.family
 }

--- a/src/gui/qt6-qml/pages/LobbyPage.qml
+++ b/src/gui/qt6-qml/pages/LobbyPage.qml
@@ -45,6 +45,15 @@ Rectangle {
         return count < maxPlayers ? Config.Theme.colorStatusOpen : Config.Theme.colorStatusFull
     }
 
+    function escapeHtml(value) {
+        return String(value === undefined || value === null ? "" : value)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;")
+    }
+
     // Kontextaktionen für das ausgewählte Spiel (Bestätigung wie im Widget-Client)
     function requestReportGame() {
         if (!selectedGame) return
@@ -1541,8 +1550,8 @@ Rectangle {
             AppLabel {
                 Layout.fillWidth: true
                 text: qsTr("You have been invited to the game <b>%1</b> by <b>%2</b>.<br>Would you like to join this game?")
-                      .arg(inviteGamePopup.inviteGameName)
-                      .arg(inviteGamePopup.inviteFromName)
+                      .arg(lobbyPage.escapeHtml(inviteGamePopup.inviteGameName))
+                      .arg(lobbyPage.escapeHtml(inviteGamePopup.inviteFromName))
                 textFormat: Text.RichText
                 color: Config.StaticData.palette.secondary.col200
                 font.pixelSize: 13


### PR DESCRIPTION
Game names and player names received from a server are displayed through shared AppText and AppLabel components. Qt's default text handling interprets HTML and can fetch remote images from <img> tags, allowing a game creator to force HTTP requests from other Qt6 clients viewing the lobby.

Set the shared components to Text.PlainText by default. The invitation popup explicitly uses rich text, so its game and player names are HTML-escaped before interpolation.