### PR TITLE
server: bound avatar cache growth from uploads

### DIFF
--- a/src/core/avatarmanager.cpp
+++ b/src/core/avatarmanager.cpp
@@ -43,6 +43,7 @@
 
 #include <fstream>
 #include <cstring>
+#include <set>
 #include <vector>
 
 #define MAX_NUMBER_OF_FILES			NetHelper::GetMaxNumberOfAvatarFiles()
@@ -433,18 +434,41 @@ AvatarManager::StoreAvatarInCache(const MD5Buf &md5buf, AvatarFileType avatarFil
 				path tmpPath(cacheDir);
 				tmpPath /= (md5buf.ToString() + ext);
 				string fileName(tmpPath.string());
+				boost::mutex::scoped_lock cacheLock(m_cachedAvatarsMutex);
 				std::ofstream o(fileName.c_str(), ios_base::out | ios_base::binary | ios_base::trunc);
 				if (!o.fail()) {
 					o.write((const char *)data, size);
 					o.close();
+
+					// A hash is the cache key, so keep only one physical file
+					// for it. Otherwise a peer could store the same hash once
+					// under each supported extension and bypass the file limit.
+					const AvatarFileType fileTypes[] = {
+						AVATAR_FILE_TYPE_PNG, AVATAR_FILE_TYPE_JPG, AVATAR_FILE_TYPE_GIF
+					};
+					for (unsigned i = 0; i < sizeof(fileTypes) / sizeof(fileTypes[0]); ++i) {
+						string otherExt(GetAvatarFileExtension(fileTypes[i]));
+						if (otherExt != ext) {
+							path otherPath(cacheDir);
+							otherPath /= (md5buf.ToString() + otherExt);
+							boost::system::error_code removeError;
+							boost::filesystem::remove(otherPath, removeError);
+							if (removeError)
+								LOG_ERROR("Failed to remove duplicate avatar cache entry.");
+						}
+					}
+
 					if (upload && m_useExternalServer) {
 						m_uploader->QueueUpload(m_externalServerAddress, m_externalServerUser, m_externalServerPassword, fileName, size);
 					}
 
-					{
-						boost::mutex::scoped_lock lock(m_cachedAvatarsMutex);
-						m_cachedAvatars.insert(AvatarMap::value_type(md5buf, fileName));
-					}
+					m_cachedAvatars[md5buf] = fileName;
+					// Keep the cache bounded when a remote peer causes a new
+					// avatar to be stored. The periodic server cleanup handles
+					// stale entries, while this prevents upload bursts from
+					// growing the cache without bound between timer runs.
+					cacheLock.unlock();
+					RemoveOldAvatarCacheEntries();
 					retVal = true;
 				}
 			}
@@ -499,6 +523,33 @@ AvatarManager::RemoveOldAvatarCacheEntries()
 		// Never delete anything if we do not have a special cache dir set.
 		if (!cacheDir.empty()) {
 			boost::mutex::scoped_lock lock(m_cachedAvatarsMutex);
+			set<string> canonicalFiles;
+			for (AvatarMap::const_iterator i = m_cachedAvatars.begin(); i != m_cachedAvatars.end(); ++i)
+				canonicalFiles.insert(path(i->second).string());
+
+			// Remove avatar cache files which share a hash with a
+			// canonical entry but are not the selected file. This also
+			// cleans duplicates left by older server versions.
+			try {
+				directory_iterator i(cachePath);
+				directory_iterator end;
+				while (i != end) {
+					if (is_regular_file(i->status())) {
+						MD5Buf tmpBuf;
+						string fileString(i->path().string());
+						if (tmpBuf.FromString(i->path().stem().string())
+								&& canonicalFiles.find(fileString) == canonicalFiles.end()) {
+							boost::system::error_code removeError;
+							boost::filesystem::remove(i->path(), removeError);
+							if (removeError)
+								LOG_ERROR("Failed to remove duplicate avatar cache entry.");
+						}
+					}
+					++i;
+				}
+			} catch (...) {
+				LOG_ERROR("Exception caught when removing duplicate avatar cache entries.");
+			}
 
 			// First pass: Remove files which no longer exist.
 			// Count files and record age.

--- a/src/net/serverlobbythread.cpp
+++ b/src/net/serverlobbythread.cpp
@@ -73,6 +73,7 @@
 #define SERVER_REMOVE_PLAYER_INTERVAL_MSEC			100
 #define SERVER_UPDATE_LOGIN_LOCK_INTERVAL_MSEC		1000
 #define SERVER_PROCESS_SEND_INTERVAL_MSEC			10
+#define SERVER_AVATAR_CACHE_CLEANUP_INTERVAL_SEC		86400
 
 #define SERVER_INIT_LOGIN_CLIENT_LOCK_SEC			NetHelper::GetLoginLockSec()
 #define SERVER_INIT_LOGIN_CLIENT_BURST				5		// inits one address may send back to back before the rate limit applies
@@ -296,6 +297,7 @@ ServerLobbyThread::ServerLobbyThread(GuiInterface &gui, ServerMode mode, ConfigF
 	  m_mode(mode), m_serverConfig(serverConfig), m_curGameId(0), m_curUniquePlayerId(0), m_curSessionId(INVALID_SESSION + 1),
 	  m_statDataChanged(false), m_removeGameTimer(*ioService),
 	  m_saveStatisticsTimer(*ioService), m_loginLockTimer(*ioService),
+	  m_avatarCleanupTimer(*ioService),
 	  m_startTime(boost::posix_time::second_clock::local_time())
 {
 	m_internalServerCallback.reset(new InternalServerCallback(*this));
@@ -1072,6 +1074,12 @@ ServerLobbyThread::RegisterTimers()
 	m_loginLockTimer.async_wait(
 		boost::bind(
 			&ServerLobbyThread::TimerUpdateClientLoginLock, shared_from_this(), boost::asio::placeholders::error));
+	// Remove stale and excess avatar cache entries periodically. The
+	// AvatarManager also enforces the limit after each new upload.
+	m_avatarCleanupTimer.expires_after(seconds(SERVER_AVATAR_CACHE_CLEANUP_INTERVAL_SEC));
+	m_avatarCleanupTimer.async_wait(
+		boost::bind(
+			&ServerLobbyThread::TimerCleanupAvatarCache, shared_from_this(), boost::asio::placeholders::error));
 }
 
 void
@@ -1080,6 +1088,7 @@ ServerLobbyThread::CancelTimers()
 	m_removeGameTimer.cancel();
 	m_saveStatisticsTimer.cancel();
 	m_loginLockTimer.cancel();
+	m_avatarCleanupTimer.cancel();
 }
 
 void
@@ -2253,6 +2262,18 @@ ServerLobbyThread::TimerUpdateClientLoginLock(const boost::system::error_code &e
 		m_loginLockTimer.async_wait(
 			boost::bind(
 				&ServerLobbyThread::TimerUpdateClientLoginLock, shared_from_this(), boost::asio::placeholders::error));
+	}
+}
+
+void
+ServerLobbyThread::TimerCleanupAvatarCache(const boost::system::error_code &ec)
+{
+	if (!ec) {
+		m_avatarManager.RemoveOldAvatarCacheEntries();
+		m_avatarCleanupTimer.expires_after(seconds(SERVER_AVATAR_CACHE_CLEANUP_INTERVAL_SEC));
+		m_avatarCleanupTimer.async_wait(
+			boost::bind(
+				&ServerLobbyThread::TimerCleanupAvatarCache, shared_from_this(), boost::asio::placeholders::error));
 	}
 }
 

--- a/src/net/serverlobbythread.h
+++ b/src/net/serverlobbythread.h
@@ -301,6 +301,7 @@ private:
 	boost::asio::steady_timer m_removeGameTimer;
 	boost::asio::steady_timer m_saveStatisticsTimer;
 	boost::asio::steady_timer m_loginLockTimer;
+	boost::asio::steady_timer m_avatarCleanupTimer;
 
 	boost::uuids::random_generator m_sessionIdGenerator;
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -97,9 +97,7 @@ bool Session::init()
 					  myQtToolsInterface->stringFromUtf8(myConfig->readConfigString("AppDataDir")),
 					  myQtToolsInterface->stringFromUtf8(myConfig->readConfigString("CacheDir")));
 	addOwnAvatar(myQtToolsInterface->stringFromUtf8(myConfig->readConfigString("MyAvatar")));
-#ifndef POKERTH_OFFICIAL_SERVER
 	myAvatarManager->RemoveOldAvatarCacheEntries();
-#endif
 	return retVal;
 }
 
@@ -659,4 +657,3 @@ bool Session::getAvatarFile(const MD5Buf &avatarMD5, std::string &fileName)
 	}
 	return retVal;
 }
-


### PR DESCRIPTION
Unauthenticated guests can supply unique avatar hashes and upload avatars up to 30 KB. Official dedicated servers skip startup cleanup and do not schedule runtime cleanup, allowing the cache to grow without bound.

Restore startup and periodic cleanup for official servers. Enforce cleanup after stored avatars and remove alternate-extension duplicates so the configured cache limit remains effective.