### PR TITLE
Limit external avatar download size

### DIFF
--- a/src/net/downloaderthread.cpp
+++ b/src/net/downloaderthread.cpp
@@ -32,6 +32,7 @@
 #include <net/downloaderthread.h>
 #include <net/downloadhelper.h>
 #include <net/netexception.h>
+#include <core/avatarmanager.h>
 #include <boost/filesystem.hpp>
 #include <core/loghelper.h>
 
@@ -132,7 +133,8 @@ DownloaderThread::Main()
 				}
 				if (m_curDownloadData && !m_curDownloadData->filename.empty()) {
 					path filepath(m_curDownloadData->filename);
-					m_downloadHelper->Init(m_curDownloadData->address, filepath.string());
+					m_downloadHelper->Init(m_curDownloadData->address, filepath.string(),
+							"", "", MAX_AVATAR_FILE_SIZE);
 					m_downloadInProgress = true;
 				}
 			}
@@ -143,4 +145,3 @@ DownloaderThread::Main()
 		}
 	}
 }
-


### PR DESCRIPTION
External avatar downloads initialize `DownloadHelper` without a maximum size. The helper therefore writes an oversized or never-ending response to the cache, and `DownloaderThread` later allocates the complete file. A listed avatar endpoint can exhaust client disk or memory, and the allocation exception is not handled.

Pass `MAX_AVATAR_FILE_SIZE` when initializing avatar downloads so the helper aborts responses that exceed the avatar limit.